### PR TITLE
Tumor mutational burden display

### DIFF
--- a/moalmanac/evaluator.py
+++ b/moalmanac/evaluator.py
@@ -198,7 +198,7 @@ class Actionable:
 
     @classmethod
     def display_burden(cls, df, idx, alt):
-        return df.loc[idx, alt].astype(str) + ' mutations per Mb'
+        return df.loc[idx, alt].astype(str)
 
     @classmethod
     def display_copynumber(cls, df, idx, feature, alt_type):

--- a/moalmanac/features.py
+++ b/moalmanac/features.py
@@ -243,6 +243,7 @@ class BurdenReader(object):
         burden_boolean = cls.evaluate_high_burden(df)
         df[cls.high_burden_boolean] = burden_boolean
         df[Features.feature] = cls.evaluate_high_burden_boolean(burden_boolean)
+        df[Features.alt] = f'{round(mutational_burden, 2)} mutations per Mb'
         return df.to_frame().T
 
 

--- a/moalmanac/test/evaluator_tests.py
+++ b/moalmanac/test/evaluator_tests.py
@@ -171,7 +171,7 @@ class UnitTestActionable(unittest.TestCase):
 
     def test_display_burden(self):
         alt = Evaluator.alt
-        df = pd.DataFrame({alt: [10, 20, 30]})
+        df = pd.DataFrame({alt: ["10 mutations per Mb", "20", "30 mutations per Mb"]})
         idx = [0, 2]
         series = Actionable.display_burden(df, idx, alt)
         self.assertEqual(['10 mutations per Mb', '30 mutations per Mb'], series.tolist())


### PR DESCRIPTION
# Type of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)

# Description
Tumor mutational burden was being incorrectly displayed under the "Feature" column within reports and the ".actionable.txt" output. Rather than printing the float value followed by "mutations per Mb", instead just "mutations per Mb" was displayed. 

# How Has This Been Tested?
The unit test `display_burden` was revised and all unit tests pass. 