### PR TITLE
Label report and additional matches output at generation

### DIFF
--- a/moalmanac/datasources.py
+++ b/moalmanac/datasources.py
@@ -148,6 +148,10 @@ class Almanac(object):
         df = Reader.read_tinydb(dbs['almanac_handle'])
         return df
 
+    @staticmethod
+    def close_ds(ds):
+        ds.close()
+
 
 class CancerGeneCensus(object):
     gene = Datasources.feature

--- a/moalmanac/matchmaker.py
+++ b/moalmanac/matchmaker.py
@@ -72,7 +72,8 @@ class Matchmaker:
 
         calculated = SNFTypesCGCwithEvidence.calculate(annotated, samples_to_use)
         case = cls.subset_dataframe_eq(calculated, 'case', cls.case_profile)
-        case.sort_values(by=SNFTypesCGCwithEvidence.label, ascending=True, inplace=True)
+        case = case.reset_index(drop=True)
+        case = case.sort_values(by=SNFTypesCGCwithEvidence.label, ascending=True)
         case['case'].replace(cls.case_profile, case_sample_id, inplace=True)
         return case
 

--- a/moalmanac/matchmaker.py
+++ b/moalmanac/matchmaker.py
@@ -83,6 +83,10 @@ class Matchmaker:
         return pd.concat([df1.loc[:, columns], df2.loc[:, columns]], ignore_index=True)
 
     @classmethod
+    def create_empty_output(cls):
+        return pd.DataFrame(columns={'case', 'comparison'})
+
+    @classmethod
     def format_fusions(cls, dataframe):
         df = dataframe[cls.alt].fillna('').str.split('--', expand=True).rename(columns={0: 'feature', 1: 'partner'})
         df[cls.model_id] = cls.case_profile

--- a/moalmanac/moalmanac.py
+++ b/moalmanac/moalmanac.py
@@ -86,7 +86,7 @@ def main(patient, inputs):
     germline_variants, germline_reject = features.MAFGermline.import_feature(inputs[germline_handle])
 
     if not somatic_variants.empty:
-        annotated_somatic = annotator.Annotator.annotate_somatic(somatic_variants, dbs, patient[code])
+        annotated_somatic = annotator.Annotator.annotate_somatic(somatic_variants, dbs, patient[code], patient[patient_id])
         evaluated_somatic = evaluator.Evaluator.evaluate_somatic(annotated_somatic)
 
         validation_accept, validation_reject = features.MAFValidation.import_feature(inputs[validation_handle])
@@ -97,7 +97,7 @@ def main(patient, inputs):
         evaluated_somatic = features.Features.create_empty_dataframe()
 
     if not germline_variants.empty:
-        annotated_germline = annotator.Annotator.annotate_germline(germline_variants, dbs, patient[code])
+        annotated_germline = annotator.Annotator.annotate_germline(germline_variants, dbs, patient[code], patient[patient_id])
         evaluated_germline = evaluator.Evaluator.evaluate_germline(annotated_germline)
     else:
         evaluated_germline = features.Features.create_empty_dataframe()
@@ -111,10 +111,10 @@ def main(patient, inputs):
     patient_ms_status = features.MicrosatelliteReader.summarize(patient[ms_status])
     patient[ms_status] = features.MicrosatelliteReader.map_status(patient[ms_status])
 
-    annotated_burden = annotator.Annotator.annotate_almanac(somatic_burden, dbs, patient[code])
-    annotated_signatures = annotator.Annotator.annotate_almanac(somatic_signatures, dbs, patient[code])
-    annotated_wgd = annotator.Annotator.annotate_almanac(patient_wgd, dbs, patient[code])
-    annotated_ms_status = annotator.Annotator.annotate_almanac(patient_ms_status, dbs, patient[code])
+    annotated_burden = annotator.Annotator.annotate_almanac(somatic_burden, dbs, patient[code], patient[patient_id])
+    annotated_signatures = annotator.Annotator.annotate_almanac(somatic_signatures, dbs, patient[code], patient[patient_id])
+    annotated_wgd = annotator.Annotator.annotate_almanac(patient_wgd, dbs, patient[code], patient[patient_id])
+    annotated_ms_status = annotator.Annotator.annotate_almanac(patient_ms_status, dbs, patient[code], patient[patient_id])
 
     evaluated_burden = evaluator.Evaluator.evaluate_almanac(annotated_burden)
     evaluated_signatures = evaluator.Evaluator.evaluate_almanac(annotated_signatures)
@@ -147,19 +147,18 @@ def main(patient, inputs):
                                       dbs_preclinical['dictionary']
                                       )
 
-    value_patient_id = patient[patient_id]
-    writer.Actionable.write(actionable, value_patient_id)
-    writer.GermlineACMG.write(evaluated_germline, value_patient_id)
-    writer.GermlineCancer.write(evaluated_germline, value_patient_id)
-    writer.GermlineHereditary.write(evaluated_germline, value_patient_id)
-    writer.Integrated.write(integrated, value_patient_id)
-    writer.MSI.write(evaluated_ms_variants, value_patient_id)
-    writer.MutationalBurden.write(evaluated_burden, value_patient_id)
-    writer.SomaticScored.write(evaluated_somatic, value_patient_id)
-    writer.SomaticFiltered.write(somatic_filtered, value_patient_id)
-    writer.Strategies.write(strategies, value_patient_id)
-    writer.PreclinicalEfficacy.write(efficacy_summary, value_patient_id)
-    writer.PreclinicalMatchmaking.write(matchmaker_results, value_patient_id)
+    writer.Actionable.write(actionable, patient[patient_id])
+    writer.GermlineACMG.write(evaluated_germline, patient[patient_id])
+    writer.GermlineCancer.write(evaluated_germline, patient[patient_id])
+    writer.GermlineHereditary.write(evaluated_germline, patient[patient_id])
+    writer.Integrated.write(integrated, patient[patient_id])
+    writer.MSI.write(evaluated_ms_variants, patient[patient_id])
+    writer.MutationalBurden.write(evaluated_burden, patient[patient_id])
+    writer.SomaticScored.write(evaluated_somatic, patient[patient_id])
+    writer.SomaticFiltered.write(somatic_filtered, patient[patient_id])
+    writer.Strategies.write(strategies, patient[patient_id])
+    writer.PreclinicalEfficacy.write(efficacy_summary, patient[patient_id])
+    writer.PreclinicalMatchmaking.write(matchmaker_results, patient[patient_id])
 
 
 if __name__ == "__main__":

--- a/moalmanac/moalmanac.py
+++ b/moalmanac/moalmanac.py
@@ -133,19 +133,19 @@ def main(patient, inputs):
     efficacy_summary = investigator.SummaryDataFrame.create(efficacy_dictionary, actionable, patient[patient_id])
     actionable = annotator.PreclinicalEfficacy.annotate(actionable, efficacy_summary)
 
-    matchmaker_results = matchmaker.Matchmaker.compare(dbs, dbs_preclinical, evaluated_somatic, patient[patient_id])
+    if inputs[disable_matchmaking]:
+        matchmaker_results = matchmaker.Matchmaker.create_empty_output()
+    else:
+        matchmaker_results = matchmaker.Matchmaker.compare(dbs, dbs_preclinical, evaluated_somatic, patient[patient_id])
 
     report_dictionary = reporter.Reporter.generate_dictionary(evaluated_somatic, patient)
-    version_dictionary = reporter.Reporter.generate_version_dictionary()
-
-    if inputs[disable_matchmaking]:
-        matchmaker_on_boolean = False
-    else:
-        matchmaker_on_boolean = True
-
-    reporter.Reporter.generate_report(actionable, report_dictionary, version_dictionary,
-                                      efficacy_dictionary, efficacy_summary,
-                                      matchmaker_on_boolean, matchmaker_results, dbs_preclinical['dictionary'])
+    reporter.Reporter.generate_report(actionable,
+                                      report_dictionary,
+                                      efficacy_dictionary,
+                                      efficacy_summary,
+                                      matchmaker_results,
+                                      dbs_preclinical['dictionary']
+                                      )
 
     value_patient_id = patient[patient_id]
     writer.Actionable.write(actionable, value_patient_id)

--- a/moalmanac/reader.py
+++ b/moalmanac/reader.py
@@ -33,7 +33,8 @@ class Reader(object):
 
     @staticmethod
     def read_pickle(handle):
-        return pickle.load(open(handle, "rb"))
+        with open(handle, 'rb') as pickle_handle:
+            return pickle.load(pickle_handle)
 
     @staticmethod
     def read_tinydb(handle):

--- a/moalmanac/reporter.py
+++ b/moalmanac/reporter.py
@@ -1,6 +1,7 @@
 import flask
 import flask_frozen
 import datetime
+import os
 import tinydb
 
 from config import COLNAMES
@@ -71,6 +72,8 @@ class Reporter(object):
                         matchmaking_on, matchmaker, preclinical_reference_dict):
         app = flask.Flask(__name__)
         freezer = flask_frozen.Freezer(app)
+        app.config['FREEZER_DESTINATION'] = f"{os.getcwd()}"
+        app.config['FREEZER_REMOVE_EXTRA_FILES'] = False  # DO NOT REMOVE THIS, FLASK FROZEN WILL DELETE FILES IF TRUE
 
         actionable = cls.drop_double_fusion(actionable)
         matches = cls.load_almanac_additional_matches()
@@ -82,7 +85,7 @@ class Reporter(object):
                 cell_line = matchmaker.loc[index, 'comparison']
                 lookup[index] = preclinical_reference_dict[cell_line]
 
-        @app.route('/')
+        @app.route(f"/{report_dictionary['patient_id']}.report.html")
         def index():
             return flask.render_template('index.html',
                                          df=actionable.fillna(''),

--- a/moalmanac/reporter.py
+++ b/moalmanac/reporter.py
@@ -67,9 +67,13 @@ class Reporter(object):
         }
 
     @classmethod
-    def generate_report(cls, actionable, report_dictionary, version_dictionary,
-                        preclinical_dictionary, preclinical_dataframe,
-                        matchmaking_on, matchmaker, preclinical_reference_dict):
+    def generate_report(cls, actionable, report_dictionary,
+                        preclinical_dictionary,
+                        preclinical_dataframe,
+                        matchmaker,
+                        preclinical_reference_dict):
+        version_dictionary = cls.generate_version_dictionary()
+
         app = flask.Flask(__name__)
         freezer = flask_frozen.Freezer(app)
         app.config['FREEZER_DESTINATION'] = f"{os.getcwd()}"
@@ -79,7 +83,7 @@ class Reporter(object):
         matches = cls.load_almanac_additional_matches()
 
         lookup = {}
-        if matchmaking_on:
+        if not matchmaker.empty:
             matchmaker = matchmaker[~matchmaker['comparison'].eq('case-profile')]
             for index in matchmaker.index.tolist()[:10]:
                 cell_line = matchmaker.loc[index, 'comparison']
@@ -94,7 +98,6 @@ class Reporter(object):
                                          matches=matches,
                                          preclinical_dict=preclinical_dictionary,
                                          preclinical_df=preclinical_dataframe,
-                                         matchmaking_on=matchmaking_on,
                                          matchmaker=matchmaker,
                                          lookup=lookup
                                          )

--- a/moalmanac/run_example.py
+++ b/moalmanac/run_example.py
@@ -54,8 +54,6 @@ cmd = ''.join(['mkdir -p ', outdir])
 execute_cmd(cmd)
 cmd = ''.join(['mv ', patient_dict['patient_id'], '* ', outdir, '/'])
 execute_cmd(cmd)
-cmd = ''.join(['mv build/index.html ', outdir, '/', patient_dict['patient_id'], '.report.html'])
-execute_cmd(cmd)
 cmd = 'rm almanac.additional.matches.json'
 execute_cmd(cmd)
 cmd = 'git checkout -- datasources/moalmanac/moalmanac.json'

--- a/moalmanac/run_example.py
+++ b/moalmanac/run_example.py
@@ -50,11 +50,9 @@ def execute_cmd(command):
 
 
 outdir = f"output-{patient_dict['patient_id']}"
-cmd = ''.join(['mkdir -p ', outdir])
+cmd = f"mkdir -p {outdir}"
 execute_cmd(cmd)
-cmd = ''.join(['mv ', patient_dict['patient_id'], '* ', outdir, '/'])
-execute_cmd(cmd)
-cmd = 'rm almanac.additional.matches.json'
+cmd = f"mv {patient_dict['patient_id']}* {outdir}/"
 execute_cmd(cmd)
 cmd = 'git checkout -- datasources/moalmanac/moalmanac.json'
 execute_cmd(cmd)

--- a/moalmanac/templates/index.html
+++ b/moalmanac/templates/index.html
@@ -15,7 +15,7 @@
             {% include 'header.html' %}
             {% include 'patient_info.html' %}
             {% include 'report_table/table.html' %}
-            {% if matchmaking_on %}
+            {% if not matchmaker.empty %}
                 {% include 'report_table/table_matchmaking.html' %}
             {% endif %}
             {% include 'footer.html' %}

--- a/moalmanac/test/annotator_tests.py
+++ b/moalmanac/test/annotator_tests.py
@@ -586,6 +586,7 @@ class UnitTestPreclinicalMatchmaking(unittest.TestCase):
         db[alteration_type] = 'Fusion'
         db_genes = ['ABL1', 'BCR', 'NTRK1', 'CDKN2A']
         result = PreclinicalMatchmaking.annotate_fusions_matching(df, db, db_genes, consider_partner=True).fillna(0)
+        datasource_Almanac.close_ds(almanac)
 
         expected_0 = {match_1: 1, match_2: 1, match_3: 1, match_4: 1, match: 4}
         expected_1 = {match_1: 1, match_2: 1, match_3: 1, match_4: 0, match: 3}


### PR DESCRIPTION
This pull request revised how the actionable report and additional output files are generated. Specifically, both files are now labeled with the provided profile id as a file name prefix at the time of generation, instead of being relabeled after the fact. 

Revisions,
-

Pre-pull request check list:
- [ ] All unit tests pass
- [ ] Outputs pre- and post- changes match by md5 hash
- [ ] All files changed have been reviewed