### PR TITLE
Specify output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Optional arguments:
     --wgd                   <boolean>   specify the occurence of whole genome duplication
     --disable_matchmaking   <boolean>   remove patient-to-cell line matchmaking from report
     --description           <string>    description of patient
+    --output-directory      <string>    specify location of produced outputs
 ```
 
 ## Example

--- a/docs/description-of-inputs.md
+++ b/docs/description-of-inputs.md
@@ -21,6 +21,7 @@ Example inputs can be found in the [`example_data/`](/example_data/) folder, fou
     - [Whole genome doubling](#whole-genome-doubling)
     - [Disable matchmaking](#disable-matchmaking)
     - [Description](#description)
+    - [Output directory](#output-directory)
     
 # Required arguments
 The following arguments are required to run Molecular Oncology Almanac.
@@ -246,6 +247,10 @@ Microsatellite status is reported in the clinical actionability report.
 
 ## Description
 `--description` is a string input that is generally a free text field for users to enter any additional comments. 
+
+## Output directory
+`--output-directory` allows users to specify an output directory to write outputs to, the current working directory will be used if unspecified. 
+
 
 If you use this method, please cite our publication:
 > [Reardon, B., Moore, N.D., Moore, N.S., *et al*. Integrating molecular profiles into clinical frameworks through the Molecular Oncology Almanac to prospectively guide precision oncology. *Nat Cancer* (2021). https://doi.org/10.1038/s43018-021-00243-3](https://www.nature.com/articles/s43018-021-00243-3)

--- a/moalmanac/features.py
+++ b/moalmanac/features.py
@@ -450,7 +450,7 @@ class CosmicSignatures:
 
     @staticmethod
     def create_handle(folder, patient_id, suffix):
-        return f"{folder}{patient_id}.{suffix}"
+        return f"{folder}/{patient_id}.{suffix}"
 
     @staticmethod
     def format_weights(weights):

--- a/moalmanac/illustrator.py
+++ b/moalmanac/illustrator.py
@@ -24,9 +24,9 @@ class Illustrator(object):
         tableau10[color] = (r / 255., g / 255., b / 255.)
 
     @staticmethod
-    def save_fig(figure, patient_id, suffix):
-        outname = '.'.join([patient_id, suffix])
-        figure.savefig(outname, bbox_inches='tight')
+    def save_fig(figure, folder, patient_id, suffix):
+        output_filename = f"{folder}/{patient_id}.{suffix}"
+        figure.savefig(output_filename, bbox_inches='tight')
 
 
 class Signatures(Illustrator):
@@ -84,21 +84,21 @@ class Signatures(Illustrator):
         return '\n'.join([base, suffix])
 
     @classmethod
-    def generate_context_plot(cls, patient_id, contexts):
+    def generate_context_plot(cls, folder, patient_id, contexts):
         title = cls.create_title('counts')
         ylabel = cls.create_ylabel('Counts')
 
         figure = cls.plot_context(contexts.astype(float), title, ylabel)
-        cls.save_fig(figure, patient_id, 'sigs.tricontext.counts.png')
+        cls.save_fig(figure, folder, patient_id, 'sigs.tricontext.counts.png')
 
     @classmethod
-    def generate_context_plot_normalized(cls, patient_id, contexts):
+    def generate_context_plot_normalized(cls, folder, patient_id, contexts):
         title = cls.create_title('normalized')
         ylabel = cls.create_ylabel('Probability')
 
         data = contexts.astype(float) / contexts.astype(float).max()
         figure = cls.plot_context(data.astype(float), title, ylabel)
-        Illustrator.save_fig(figure, patient_id, 'sigs.tricontext.normalized.png')
+        Illustrator.save_fig(figure, folder, patient_id, 'sigs.tricontext.normalized.png')
 
 
 class ValidationOverlap(Illustrator):
@@ -187,10 +187,10 @@ class ValidationOverlap(Illustrator):
         return fig
 
     @classmethod
-    def generate_dna_rna_plot(cls, df, patient_id):
+    def generate_dna_rna_plot(cls, df, patient_id, folder):
         data = cls.format_data(df)
         figure = cls.plot_overlap_af(data, title=patient_id)
-        Illustrator.save_fig(figure, patient_id, 'validation_overlap.png')
+        Illustrator.save_fig(figure, folder, patient_id, 'validation_overlap.png')
 
 
 class PreclinicalEfficacy(Illustrator):
@@ -222,9 +222,9 @@ class PreclinicalEfficacy(Illustrator):
         return yticks
 
     @classmethod
-    def draw(cls, dictionary, drug, features, patient_id, feature_str):
+    def draw(cls, dictionary, drug, features, patient_id, feature_str, folder):
         figure = cls.plot_boxplots(dictionary, drug, features)
-        Illustrator.save_fig(figure, patient_id, '.'.join([feature_str, drug.split(' ')[0], 'png']))
+        Illustrator.save_fig(figure, folder, patient_id, f"{feature_str}.{drug.split(' ')[0]}.png")
         return cls.convert_figure_base64(figure)
 
     @classmethod

--- a/moalmanac/investigator.py
+++ b/moalmanac/investigator.py
@@ -122,7 +122,7 @@ class SensitivityDictionary(Investigator):
             return stats.mannwhitneyu(series1, series2, alternative='two-sided')
 
     @classmethod
-    def create(cls, dbs, df_actionable, patient_id):
+    def create(cls, dbs, df_actionable, patient_id, output_folder):
         summary = dbs[cls.summary]
         variants = dbs[cls.variants]
         cnas = dbs[cls.cnas]
@@ -153,7 +153,7 @@ class SensitivityDictionary(Investigator):
                         drug_dict = cls.create_drug_dict(gdsc, therapy, wt_samples, mut_samples)
                         feature_dict_copy.update({'comparison': drug_dict})
                         therapy_dict.update({feature: feature_dict_copy})
-                    figure = PreclinicalEfficacy.draw(therapy_dict, therapy, features, patient_id, feature_display)
+                    figure = PreclinicalEfficacy.draw(therapy_dict, therapy, features, patient_id, feature_display, output_folder)
                     therapy_dict.update({'figure': figure})
                     index_dict.update({therapy: therapy_dict})
                 dictionary.update({index: index_dict})

--- a/moalmanac/matchmaker.py
+++ b/moalmanac/matchmaker.py
@@ -299,7 +299,11 @@ class Almanac(Models):
     @classmethod
     def sort_fusions(cls, df, gene1_col, gene2_col):
         for index in df.index:
-            df.loc[index, [gene1_col, gene2_col]] = sorted(df.loc[index, [gene1_col, gene2_col]].tolist())
+            gene1 = df.loc[index, gene1_col]
+            gene2 = df.loc[index, gene2_col]
+            sorted_genes = sorted([gene1, gene2])
+            df.loc[index, gene1_col] = sorted_genes[0]
+            df.loc[index, gene2_col] = sorted_genes[1]
         return df
 
 
@@ -371,7 +375,7 @@ class AlmanacFeatures(Almanac):
     @classmethod
     def subset_fusions(cls, df):
         dataframe = df[df[cls.feature_match_4].eq(1)]
-        return cls.sort_fusions(dataframe, cls.feature, cls.partner).reset_index(drop=True)
+        return cls.sort_fusions(dataframe.reset_index(drop=True), cls.feature, cls.partner)
 
     @classmethod
     def subset_fusion_members(cls, df):

--- a/moalmanac/reporter.py
+++ b/moalmanac/reporter.py
@@ -76,7 +76,7 @@ class Reporter(object):
         version_dictionary = cls.generate_version_dictionary()
 
         app = flask.Flask(__name__)
-        freezer = flask_frozen.Freezer(app)
+        freezer = flask_frozen.Freezer(app, with_no_argument_rules=False, log_url_for=False)
         app.config['FREEZER_DESTINATION'] = f"{os.getcwd()}" if output_directory == "" else output_directory
         app.config['FREEZER_REMOVE_EXTRA_FILES'] = False  # DO NOT REMOVE THIS, FLASK FROZEN WILL DELETE FILES IF TRUE
 
@@ -90,6 +90,9 @@ class Reporter(object):
                 cell_line = matchmaker.loc[index, 'comparison']
                 lookup[index] = preclinical_reference_dict[cell_line]
 
+        from warnings import simplefilter as filter_warnings
+        filter_warnings('ignore', flask_frozen.MissingURLGeneratorWarning)
+
         @app.route(f"/{report_dictionary['patient_id']}.report.html")
         def index():
             return flask.render_template('index.html',
@@ -102,6 +105,7 @@ class Reporter(object):
                                          matchmaker=matchmaker,
                                          lookup=lookup
                                          )
+
         freezer.freeze()
 
     @classmethod

--- a/moalmanac/reporter.py
+++ b/moalmanac/reporter.py
@@ -71,16 +71,17 @@ class Reporter(object):
                         preclinical_dictionary,
                         preclinical_dataframe,
                         matchmaker,
-                        preclinical_reference_dict):
+                        preclinical_reference_dict,
+                        output_directory):
         version_dictionary = cls.generate_version_dictionary()
 
         app = flask.Flask(__name__)
         freezer = flask_frozen.Freezer(app)
-        app.config['FREEZER_DESTINATION'] = f"{os.getcwd()}"
+        app.config['FREEZER_DESTINATION'] = f"{os.getcwd()}" if output_directory == "" else output_directory
         app.config['FREEZER_REMOVE_EXTRA_FILES'] = False  # DO NOT REMOVE THIS, FLASK FROZEN WILL DELETE FILES IF TRUE
 
         actionable = cls.drop_double_fusion(actionable)
-        matches = cls.load_almanac_additional_matches()
+        matches = cls.load_almanac_additional_matches(output_directory, report_dictionary['patient_id'])
 
         lookup = {}
         if not matchmaker.empty:
@@ -114,8 +115,11 @@ class Reporter(object):
                 )
 
     @staticmethod
-    def load_almanac_additional_matches():
-        handle = CONFIG['databases']['additional_matches']
+    def load_almanac_additional_matches(output_folder, patient_id):
+        if output_folder == "":
+            handle = f"{patient_id}.{CONFIG['databases']['additional_matches']}"
+        else:
+            handle = f"{output_folder}/{patient_id}.{CONFIG['databases']['additional_matches']}"
         db = tinydb.TinyDB(handle)
         matches = {}
         for table in db.tables():

--- a/moalmanac/run_deconstructsigs.R
+++ b/moalmanac/run_deconstructsigs.R
@@ -9,24 +9,26 @@ ref = args[4]
 alt = args[5]
 chr = args[6]
 pos = args[7]
+folder = args[8]
 
 maf = read.csv(snv_handle, sep = '\t', comment.char = '#')
+names(maf) <- tolower(names(maf))
 cols = c(sample, ref, alt, chr, pos)
 maf <- maf[colnames(maf) %in% cols]
 
-maf$Tumor_Sample_Barcode <- sapply(maf$Tumor_Sample_Barcode, as.factor)
-maf$Reference_Allele <- sapply(maf$Reference_Allele, as.factor)
-maf$Tumor_Seq_Allele2 <- sapply(maf$Tumor_Seq_Allele2, as.factor)
-maf$Chromosome <- sapply(maf$Chromosome, as.factor)
+maf$tumor_sample_barcode <- sapply(maf$tumor_sample_barcode, as.factor)
+maf$reference_allele <- sapply(maf$reference_allele, as.factor)
+maf$tumor_seq_allele2 <- sapply(maf$tumor_seq_allele2, as.factor)
+maf$chromosome <- sapply(maf$chromosome, as.factor)
 
-unique.samples = unique(maf$Tumor_Sample_Barcode)
+unique.samples = unique(maf$tumor_sample_barcode)
 
 sigs.input <- mut.to.sigs.input(mut.ref = maf,
     sample.id = sample, chr = chr,
     pos = pos, ref = ref,
     alt = alt)
     
-temp.filename <- paste(patient_id, ".sigs.context.txt", sep = "")
+temp.filename <- paste(folder, patient_id, ".sigs.context.txt", sep = "")
 write.table(sigs.input, file = temp.filename, sep = '\t', row.names = FALSE)
 
 for (sample_ in unique.samples) {
@@ -34,6 +36,6 @@ for (sample_ in unique.samples) {
         signatures.ref = signatures.cosmic, sample.id = sample_, 
         context = TRUE, tri.counts.method = 'default')
     
-    temp.filename = paste(patient_id, ".sigs.cosmic.txt", sep = "")
+    temp.filename = paste(folder, patient_id, ".sigs.cosmic.txt", sep = "")
     write.table(output.sigs, file = temp.filename, sep = '\t', row.names = FALSE)
 }

--- a/moalmanac/run_example.py
+++ b/moalmanac/run_example.py
@@ -1,4 +1,5 @@
 import moalmanac
+import os
 import time
 import subprocess
 
@@ -37,22 +38,24 @@ example_dict = {
     'disable_matchmaking': False
 }
 
-start_time = time.time()
-moalmanac.main(patient_dict, example_dict)
-end_time = time.time()
-
-time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round((end_time - start_time), 4)
-print(time_statement)
-
 
 def execute_cmd(command):
     subprocess.call(command, shell=True)
 
 
-outdir = f"output-{patient_dict['patient_id']}"
-cmd = f"mkdir -p {outdir}"
-execute_cmd(cmd)
-cmd = f"mv {patient_dict['patient_id']}* {outdir}/"
-execute_cmd(cmd)
+output_directory = ""
+if output_directory != "":
+    cmd = f"mkdir -p {output_directory}"
+    execute_cmd(cmd)
+else:
+    output_directory = os.getcwd()
+
+start_time = time.time()
+moalmanac.main(patient_dict, example_dict, output_directory)
+end_time = time.time()
+
+time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round((end_time - start_time), 4)
+print(time_statement)
+
 cmd = 'git checkout -- datasources/moalmanac/moalmanac.json'
 execute_cmd(cmd)

--- a/moalmanac/test/features_tests.py
+++ b/moalmanac/test/features_tests.py
@@ -120,6 +120,59 @@ class UnitTestCopyNumberTotal(unittest.TestCase):
         self.assertEqual(expected, features.CopyNumberTotal.get_unique_segments(df).tolist())
 
 
+class UnitTestCosmicSignatures(unittest.TestCase):
+    def test_create_feature_dataframe(self):
+        string = {features.CosmicSignatures.patient_id: "Example"}
+        weights = {
+            'COSMIC signature 1': 0,
+            'COSMIC signature 3': 0.5,
+            'COSMIC signature 7': 1.0
+        }
+        series = pd.Series(weights)
+        result = features.CosmicSignatures.create_feature_dataframe(string, series)
+        self.assertEqual(True, isinstance(result, pd.DataFrame))
+        self.assertEqual(3, result.shape[0])
+        self.assertEqual('COSMIC signature 1', result.loc[0, features.Features.feature])
+        self.assertEqual('COSMIC signature 3', result.loc[1, features.Features.feature])
+        self.assertEqual('COSMIC signature 7', result.loc[2, features.Features.feature])
+        self.assertEqual(0, result.loc[0, features.Features.alt])
+        self.assertEqual(0.5, result.loc[1, features.Features.alt])
+        self.assertEqual(1.0, result.loc[2, features.Features.alt])
+
+    def test_create_handle(self):
+        string1 = '.'
+        string2 = 'Foo'
+        string3 = 'Bar'
+        self.assertEqual('./Foo.Bar', features.CosmicSignatures.create_handle(string1, string2, string3))
+
+    def test_format_weights(self):
+        weights = {
+            'weights.signature.1': 0,
+            'weights.signature.3': 0.5,
+            'weights.signature 7': 1.0
+        }
+        series = pd.Series(weights)
+        result = features.CosmicSignatures.format_weights(series)
+        self.assertEqual(2, result.shape[0])
+        self.assertEqual('COSMIC signature 3', result.index[0])
+        self.assertEqual('COSMIC signature 7', result.index[1])
+
+    def test_subset_significant_signatures(self):
+        weights = {
+            'COSMIC signature 1': 0,
+            'COSMIC signature 3': 0.5,
+            'COSMIC signature 7': 1.0,
+            'COSMIC signature 10': 0.2,
+            'COSMIC signature 11': 0.19,
+        }
+        series = pd.Series(weights)
+        result = features.CosmicSignatures.subset_significant_signatures(series)
+        self.assertEqual(3, result.shape[0])
+        self.assertEqual('COSMIC signature 3', result.index[0])
+        self.assertEqual('COSMIC signature 7', result.index[1])
+        self.assertEqual('COSMIC signature 10', result.index[2])
+
+
 class UnitTestFusion(unittest.TestCase):
     def test_create_column_map(self):
         column_map = features.Fusion.create_colmap()

--- a/moalmanac/test/investigator_tests.py
+++ b/moalmanac/test/investigator_tests.py
@@ -59,7 +59,7 @@ class UnitTestSensitivityDictionary(unittest.TestCase):
         patient_id = 'example'
         expected_dabrafenib = '2.322e-12'
         expected_trametinib = '2.344e-09'
-        result = SensitivityDictionary.create(dbs, actionable, patient_id)
+        result = SensitivityDictionary.create(dbs, actionable, patient_id, '.')
         self.assertEqual(result[0]['Dabrafenib']['BRAF']['comparison']['pvalue_mww'], expected_dabrafenib)
         self.assertEqual(result[0]['Trametinib']['BRAF']['comparison']['pvalue_mww'], expected_trametinib)
 

--- a/moalmanac/test/writer_tests.py
+++ b/moalmanac/test/writer_tests.py
@@ -6,9 +6,10 @@ from writer import Writer, GermlineCancer
 
 class UnitTestWriter(unittest.TestCase):
     def test_create_output_name(self):
-        string1 = 'Foo'
-        string2 = 'Bar'
-        self.assertEqual('Foo.Bar', Writer.create_output_name(string1, string2))
+        string1 = '.'
+        string2 = 'Foo'
+        string3 = 'Bar'
+        self.assertEqual('./Foo.Bar', Writer.create_output_name(string1, string2, string3))
 
     def test_sort_columns(self):
         df = pd.DataFrame({'A': [0, 1, 2], 'B': [1, 1, 2]})

--- a/moalmanac/wrapper_deconstructsigs.sh
+++ b/moalmanac/wrapper_deconstructsigs.sh
@@ -7,5 +7,6 @@ ref=$4
 alt=$5
 chr=$6
 pos=$7
+folder=$8
 
-Rscript run_deconstructsigs.R ${patient_id} ${snv_handle} ${sample} ${ref} ${alt} ${chr} ${pos}
+Rscript run_deconstructsigs.R ${patient_id} ${snv_handle} ${sample} ${ref} ${alt} ${chr} ${pos} ${folder}

--- a/moalmanac/writer.py
+++ b/moalmanac/writer.py
@@ -101,8 +101,8 @@ class Writer(object):
     normal = COLNAMES[section]['normal']
 
     @staticmethod
-    def create_output_name(patient_id, output_suffix):
-        return '.'.join([patient_id, output_suffix])
+    def create_output_name(folder, patient_id, output_suffix):
+        return f'{folder}/{patient_id}.{output_suffix}'
 
     @staticmethod
     def export_series(series, output_name):
@@ -150,10 +150,10 @@ class Actionable(object):
     output_suffix = 'actionable.txt'
 
     @classmethod
-    def write(cls, df, patient_id):
+    def write(cls, df, patient_id, folder):
         df[Writer.patient_id] = patient_id
         df_sorted = Writer.sort_columns(df, cls.sort_columns, False)
-        output_name = Writer.create_output_name(patient_id, cls.output_suffix)
+        output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
         Writer.export_dataframe(df_sorted.loc[:, cls.output_columns].replace('nan', '').fillna(''), output_name)
         return df_sorted
 
@@ -175,11 +175,11 @@ class GermlineACMG(object):
     bin = Writer.acmg_bin
 
     @classmethod
-    def write(cls, df, patient_id):
+    def write(cls, df, patient_id, folder):
         df[Writer.patient_id] = patient_id
         df_sorted = Writer.sort_columns(df, cls.sort_columns, False)
         idx = Writer.return_nonzero_bin_idx(df.loc[:, cls.bin])
-        output_name = Writer.create_output_name(patient_id, cls.output_suffix)
+        output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
         Writer.export_dataframe(df_sorted.loc[idx, cls.output_columns].replace('nan', '').fillna(''), output_name)
 
 
@@ -213,11 +213,11 @@ class GermlineCancer(object):
         return idx_almanac.union(idx_hotspot).union(idx_cgc)
 
     @classmethod
-    def write(cls, df, patient_id):
+    def write(cls, df, patient_id, folder):
         df[Writer.patient_id] = patient_id
         df_sorted = Writer.sort_columns(df, cls.sort_columns, cls.sort_ascending)
         idx = cls.get_cancer_idx(df)
-        output_name = Writer.create_output_name(patient_id, cls.output_suffix)
+        output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
         Writer.export_dataframe(df_sorted.loc[idx, cls.output_columns].replace('nan', '').fillna(''), output_name)
 
 
@@ -238,11 +238,11 @@ class GermlineHereditary(object):
     bin = Writer.hereditary_bin
 
     @classmethod
-    def write(cls, df, patient_id):
+    def write(cls, df, patient_id, folder):
         df[Writer.patient_id] = patient_id
         df_sorted = Writer.sort_columns(df, cls.sort_columns, False)
         idx = Writer.return_nonzero_bin_idx(df.loc[:, cls.bin])
-        output_name = Writer.create_output_name(patient_id, cls.output_suffix)
+        output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
         Writer.export_dataframe(df_sorted.loc[idx, cls.output_columns].replace('nan', '').fillna(''), output_name)
 
 
@@ -258,9 +258,9 @@ class Integrated(object):
     output_suffix = 'integrated.summary.txt'
 
     @classmethod
-    def write(cls, df, patient_id):
+    def write(cls, df, patient_id, folder):
         df_sorted = df.sort_index()
-        output_name = Writer.create_output_name(patient_id, cls.output_suffix)
+        output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
         Writer.export_dataframe_indexed(df_sorted.loc[:, cls.output_columns].fillna(''), output_name, Writer.feature)
 
 
@@ -287,10 +287,10 @@ class MSI(object):
     bin = Writer.msi_bin
 
     @classmethod
-    def write(cls, df, patient_id):
+    def write(cls, df, patient_id, folder):
         df[Writer.patient_id] = patient_id
         df_sorted = Writer.sort_columns(df, cls.sort_columns, False)
-        output_name = Writer.create_output_name(patient_id, cls.output_suffix)
+        output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
         Writer.export_dataframe(df_sorted.loc[:, cls.output_columns].replace('nan', '').fillna(''), output_name)
 
 
@@ -314,9 +314,9 @@ class MutationalBurden(object):
     output_suffix = 'mutational_burden.txt'
 
     @classmethod
-    def write(cls, df, patient_id):
+    def write(cls, df, patient_id, folder):
         df[Writer.patient_id] = patient_id
-        output_name = Writer.create_output_name(patient_id, cls.output_suffix)
+        output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
         Writer.export_dataframe(df.loc[:, cls.output_columns].fillna(''), output_name)
 
 
@@ -324,8 +324,8 @@ class PreclinicalEfficacy(object):
     output_suffix = 'preclinical.efficacy.txt'
 
     @classmethod
-    def write(cls, df, patient_id):
-        output_name = Writer.create_output_name(patient_id, cls.output_suffix)
+    def write(cls, df, patient_id, folder):
+        output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
         Writer.export_dataframe(df.fillna(''), output_name)
 
 
@@ -333,8 +333,8 @@ class PreclinicalMatchmaking(object):
     output_suffix = 'matchmaker.txt'
 
     @classmethod
-    def write(cls, df, patient_id):
-        output_name = Writer.create_output_name(patient_id, cls.output_suffix)
+    def write(cls, df, patient_id, folder):
+        output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
         Writer.export_dataframe(df.fillna(''), output_name)
 
 
@@ -351,10 +351,10 @@ class SomaticFiltered(object):
     output_suffix = 'somatic.filtered.txt'
 
     @classmethod
-    def write(cls, df, patient_id):
+    def write(cls, df, patient_id, folder):
         df[Writer.patient_id] = patient_id
         df_sorted = Writer.sort_columns(df, cls.sort_columns, False)
-        output_name = Writer.create_output_name(patient_id, cls.output_suffix)
+        output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
         Writer.export_dataframe(df_sorted.loc[:, cls.output_columns].replace('nan', '').fillna(''), output_name)
 
 
@@ -380,10 +380,10 @@ class SomaticScored(object):
     output_suffix = 'somatic.scored.txt'
 
     @classmethod
-    def write(cls, df, patient_id):
+    def write(cls, df, patient_id, folder):
         df[Writer.patient_id] = patient_id
         df_sorted = Writer.sort_columns(df, cls.sort_columns, cls.sort_ascending)
-        output_name = Writer.create_output_name(patient_id, cls.output_suffix)
+        output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
         Writer.export_dataframe(df_sorted.loc[:, cls.output_columns].replace('nan', '').fillna(''), output_name)
 
 
@@ -391,8 +391,8 @@ class Strategies:
     output_suffix = 'therapeutic_strategies.txt'
 
     @classmethod
-    def write(cls, df, patient_id):
-        output_name = Writer.create_output_name(patient_id, cls.output_suffix)
+    def write(cls, df, patient_id, folder):
+        output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
         Writer.export_dataframe_indexed(df, output_name, 'Assertion / Strategy')
 
 

--- a/moalmanac/writer.py
+++ b/moalmanac/writer.py
@@ -154,7 +154,7 @@ class Actionable(object):
         df[Writer.patient_id] = patient_id
         df_sorted = Writer.sort_columns(df, cls.sort_columns, False)
         output_name = Writer.create_output_name(folder, patient_id, cls.output_suffix)
-        Writer.export_dataframe(df_sorted.loc[:, cls.output_columns].replace('nan', '').fillna(''), output_name)
+        Writer.export_dataframe(df_sorted.loc[:, cls.output_columns].fillna(''), output_name)
         return df_sorted
 
 

--- a/moalmanac/writer.py
+++ b/moalmanac/writer.py
@@ -2,7 +2,7 @@ from config import COLNAMES
 import json
 
 
-class Writer(object):
+class Writer:
     section = 'outputs'
     score_bin = COLNAMES[section]['score_bin']
     almanac_bin = COLNAMES[section]['almanac_bin']
@@ -125,7 +125,7 @@ class Writer(object):
         return series[series.astype(float) != 0].index
 
 
-class Actionable(object):
+class Actionable:
     sort_columns = [Writer.almanac_bin, Writer.sensitive_map,  Writer.resistance_map, Writer.prognostic_map]
     output_columns = [Writer.score_bin,
                       Writer.sensitive_implication, Writer.resistance_implication, Writer.prognostic_implication,
@@ -158,7 +158,7 @@ class Actionable(object):
         return df_sorted
 
 
-class GermlineACMG(object):
+class GermlineACMG:
     sort_columns = [Writer.clinvar_bin, Writer.feature, Writer.feature_type]
     output_columns = [Writer.feature_type, Writer.feature, Writer.alt_type, Writer.alt,
                       Writer.chr, Writer.start, Writer.end, Writer.ref, Writer.allele1, Writer.allele2,
@@ -183,7 +183,7 @@ class GermlineACMG(object):
         Writer.export_dataframe(df_sorted.loc[idx, cls.output_columns].replace('nan', '').fillna(''), output_name)
 
 
-class GermlineCancer(object):
+class GermlineCancer:
     sort_columns = [Writer.almanac_bin, Writer.cancerhotspots_bin, Writer.cancerhotspots3D_bin,
                     Writer.cgc_bin, Writer.gsea_pathways_bin, Writer.gsea_cm_bin, Writer.cosmic_bin,
                     Writer.exac_common, Writer.exac_af]
@@ -221,7 +221,7 @@ class GermlineCancer(object):
         Writer.export_dataframe(df_sorted.loc[idx, cls.output_columns].replace('nan', '').fillna(''), output_name)
 
 
-class GermlineHereditary(object):
+class GermlineHereditary:
     sort_columns = [Writer.clinvar_bin, Writer.feature, Writer.feature_type]
     output_columns = [Writer.feature_type, Writer.feature, Writer.alt_type, Writer.alt,
                       Writer.chr, Writer.start, Writer.end, Writer.ref, Writer.allele1, Writer.allele2,
@@ -246,7 +246,7 @@ class GermlineHereditary(object):
         Writer.export_dataframe(df_sorted.loc[idx, cls.output_columns].replace('nan', '').fillna(''), output_name)
 
 
-class Integrated(object):
+class Integrated:
     section = 'integrative'
     somatic = COLNAMES[section]['somatic']
     copynumber = COLNAMES[section]['copynumber']
@@ -264,7 +264,7 @@ class Integrated(object):
         Writer.export_dataframe_indexed(df_sorted.loc[:, cls.output_columns].fillna(''), output_name, Writer.feature)
 
 
-class MSI(object):
+class MSI:
     sort_columns = [Writer.almanac_bin, Writer.cancerhotspots_bin, Writer.cancerhotspots3D_bin,
                     Writer.cgc_bin, Writer.gsea_pathways_bin, Writer.gsea_cm_bin, Writer.cosmic_bin,
                     Writer.exac_common, Writer.exac_af]
@@ -294,7 +294,7 @@ class MSI(object):
         Writer.export_dataframe(df_sorted.loc[:, cls.output_columns].replace('nan', '').fillna(''), output_name)
 
 
-class MutationalBurden(object):
+class MutationalBurden:
     section = 'burden'
     patient = COLNAMES[section]['patient']
     tumor_type = COLNAMES[section]['tumor_type']
@@ -320,7 +320,7 @@ class MutationalBurden(object):
         Writer.export_dataframe(df.loc[:, cls.output_columns].fillna(''), output_name)
 
 
-class PreclinicalEfficacy(object):
+class PreclinicalEfficacy:
     output_suffix = 'preclinical.efficacy.txt'
 
     @classmethod
@@ -329,7 +329,7 @@ class PreclinicalEfficacy(object):
         Writer.export_dataframe(df.fillna(''), output_name)
 
 
-class PreclinicalMatchmaking(object):
+class PreclinicalMatchmaking:
     output_suffix = 'matchmaker.txt'
 
     @classmethod
@@ -338,7 +338,7 @@ class PreclinicalMatchmaking(object):
         Writer.export_dataframe(df.fillna(''), output_name)
 
 
-class SomaticFiltered(object):
+class SomaticFiltered:
     sort_columns = [Writer.feature, Writer.feature_type]
     output_columns = [Writer.feature_type, Writer.feature, Writer.alt_type, Writer.alt,
                       Writer.chr, Writer.start, Writer.end, Writer.ref, Writer.allele1, Writer.allele2,
@@ -358,7 +358,7 @@ class SomaticFiltered(object):
         Writer.export_dataframe(df_sorted.loc[:, cls.output_columns].replace('nan', '').fillna(''), output_name)
 
 
-class SomaticScored(object):
+class SomaticScored:
     sort_columns = [Writer.almanac_bin, Writer.cancerhotspots_bin, Writer.cancerhotspots3D_bin,
                     Writer.cgc_bin, Writer.gsea_pathways_bin, Writer.gsea_cm_bin, Writer.cosmic_bin,
                     Writer.validation_detection_power, Writer.validation_coverage, Writer.number_germline_mutations,
@@ -396,7 +396,7 @@ class Strategies:
         Writer.export_dataframe_indexed(df, output_name, 'Assertion / Strategy')
 
 
-class Json(object):
+class Json:
     @staticmethod
     def write(handle, dictionary):
         with open(handle, 'w') as json_handle:


### PR DESCRIPTION
This pull request revises the codebase to allow users to specify an output directory with the `--output_directory` argument. All outputs are affected; text, json, and image outputs generated by Python as well as text outputs generated by R as a subprocess.

Additions:
- Added `--output_directory` as an input argument. 

Revisions:
- With the addition of the `--output_directory` argument, this argument is passed to the main function and also passed to the annotator, features, investigator, illustrator, and writer Python modules. Additionally, it is passed to the R process scripts to properly place produced outputs. 
- The specified `--output_directory` will be created if it does not exist. This is performed in both `moalmanac.py` and `run_example.py`.
- Unit tests were written and revised in `feature_tests.py`, `investigator_tests.py`, and `writer_tests.py` to accommodate the changes for the output directory argument.  
- Documentation was updated to describe the `--output-directory` argument; `README.md` in the root directory and `docs/description-of-inputs.md`. 

Bug fixes:
- `run_deconstructsigs.R` was changed to handle all input columns as lowercase, per importing input files with lowercase column names as changed in [this pull request](https://github.com/vanallenlab/moalmanac/pull/5). 
- `matchmaker.py` was revised to resolve a warning that occurred when sorting gene names from a fusion,
```
SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead
```
- `writer.py` was revised to resolve a warning produced when writing the output `actionable.txt`,
```
indexing.html#returning-a-view-versus-a-copy
  self.obj[item] = s
/opt/miniconda3/envs/moalmanac/lib/python3.6/site-packages/pandas/core/missing.py:47: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  mask = arr == x
```
- `reporter.py` was revised to remove a warning produced regarding the URL generator

Pre-pull request check list,
- [x] Relevant documentation has been updated
- [x] All unit tests pass
- [x] All outputs pre- and post- changes match by md5 hash
- [x] All files changed have been reviewed