### PR TITLE
Bug fix: Report generation without preclinical efficacy data

### DIFF
--- a/moalmanac/reporter.py
+++ b/moalmanac/reporter.py
@@ -55,6 +55,9 @@ class Reporter:
             if column in dataframe.columns:
                 dataframe[column] = cls.preallocate_matches_columns(dataframe[column])
 
+        if 'preclinical_efficacy_lookup' in dataframe.columns:
+            dataframe['preclinical_efficacy_lookup'].fillna('', inplace=True)
+
         return dataframe
 
     @staticmethod

--- a/moalmanac/templates/modals/efficacy.html
+++ b/moalmanac/templates/modals/efficacy.html
@@ -1,52 +1,54 @@
-{% if (report.alterations.loc[index, 'preclinical_efficacy_lookup'] != '') %}
-    <div id="preclinicalModal_{{ index }}" class="modal fade" role="dialog">
-        <div class="modal-dialog modal-lg">
+{% if 'preclinical_efficacy_lookup' in report.alterations.columns.tolist() %}
+    {% if report.alterations.loc[index, 'preclinical_efficacy_lookup'] != '' %}
+        <div id="preclinicalModal_{{ index }}" class="modal fade" role="dialog">
+            <div class="modal-dialog modal-lg">
 
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal">
-                        &times;
-                    </button>
-                    <h4 class="modal-title">
-                        {{ report.alterations.loc[index, 'feature_display'] }} and sensitivity to
-                        {{ report.alterations.loc[index, 'sensitive_therapy_name'] }}
-                    </h4>
-                </div>
-                <div class="modal-body">
-                    <ul class="nav nav-tabs" id="tabContent">
-                        {% set lookup = report.alterations.loc[index, 'preclinical_efficacy_lookup'][0] %}
-                        {% for therapy in lookup.keys() %}
-                            {% if loop.index0 == 0 %}<li class="active">{% else %}<li>{% endif %}
-                            <a href="#tab{{ loop.index0 }}" data-toggle="tab">
-                                {{ therapy }}
-                            </a>
-                        </li>
-                        {% endfor %}
-                    </ul>
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal">
+                            &times;
+                        </button>
+                        <h4 class="modal-title">
+                            {{ report.alterations.loc[index, 'feature_display'] }} and sensitivity to
+                            {{ report.alterations.loc[index, 'sensitive_therapy_name'] }}
+                        </h4>
+                    </div>
+                    <div class="modal-body">
+                        <ul class="nav nav-tabs" id="tabContent">
+                            {% set lookup = report.alterations.loc[index, 'preclinical_efficacy_lookup'][0] %}
+                            {% for therapy in lookup.keys() %}
+                                {% if loop.index0 == 0 %}<li class="active">{% else %}<li>{% endif %}
+                                <a href="#tab{{ loop.index0 }}" data-toggle="tab">
+                                    {{ therapy }}
+                                </a>
+                            </li>
+                            {% endfor %}
+                        </ul>
 
-                    <div class="tab-content">
-                        {% for therapy in lookup.keys() %}
-                            {% if loop.index0 == 0 %}
-                                <div class="tab-pane active" id="tab{{ loop.index0 }}">
-                            {% else %}
-                                <div class="tab-pane" id="tab{{ loop.index0 }}">
-                            {% endif %}
-                                    <center>
-                                        <img class="logo" src="data:image/png;base64,{{ lookup[therapy]['figure_base64'] }}" style="height:500px">
-                                        {% include 'modals/text_preclinical.html' %}
-                                        {% include 'modals/table_preclinical.html' %}
-                                    </center>
-                                </div>
-                        {% endfor %}
+                        <div class="tab-content">
+                            {% for therapy in lookup.keys() %}
+                                {% if loop.index0 == 0 %}
+                                    <div class="tab-pane active" id="tab{{ loop.index0 }}">
+                                {% else %}
+                                    <div class="tab-pane" id="tab{{ loop.index0 }}">
+                                {% endif %}
+                                        <center>
+                                            <img class="logo" src="data:image/png;base64,{{ lookup[therapy]['figure_base64'] }}" style="height:500px">
+                                            {% include 'modals/text_preclinical.html' %}
+                                            {% include 'modals/table_preclinical.html' %}
+                                        </center>
+                                    </div>
+                            {% endfor %}
+                        </div>
                     </div>
                 </div>
+
             </div>
-
         </div>
-    </div>
 
-    <br>
-    <a data-toggle="modal" data-target="#preclinicalModal_{{ index }}">
-        [Preclinical evidence]
-    </a>
+        <br>
+        <a data-toggle="modal" data-target="#preclinicalModal_{{ index }}">
+            [Preclinical evidence]
+        </a>
+   {% endif %}
 {% endif %}


### PR DESCRIPTION
This pull request resolves a bug that was introduced in [Pull Request #9](https://github.com/vanallenlab/moalmanac/pull/9). Reports generated without preclinical efficacy being calculated would fail. 

Bug fixes:
- Template for preclinical efficacy was updated to check to see if preclinical efficacy is an available column in the provided dataframe. If it is, null values were converted to empty strings. 

Pre-pull request check list,
- [x] Relevant documentation has been updated
- [x] All unit tests pass
- [x] All outputs pre- and post- changes match by md5 hash
- [x] All files changed have been reviewed