### PR TITLE
Added AIP to hereditary cancers gene list

### DIFF
--- a/moalmanac/datasources/hereditary/README.md
+++ b/moalmanac/datasources/hereditary/README.md
@@ -1,5 +1,5 @@
 # Databases: Hereditary Cancers
-The Molecular Oncology Almanac utilizes a curated list of 83 genes related to hereditary cancers, modified from [Kurian et al. 2013](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4067941/)
+The Molecular Oncology Almanac utilizes a curated list of 84 genes related to hereditary cancers, modified from [Kurian et al. 2013](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4067941/). 
 
 ## References
 1. [Kurian, A. W. et al. Clinical evaluation of a multiple-gene sequencing panel for hereditary cancer risk assessment. J. Clin. Oncol. 32, 2001–2009 (2014).](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4067941/)

--- a/moalmanac/datasources/hereditary/hereditary.txt
+++ b/moalmanac/datasources/hereditary/hereditary.txt
@@ -1,4 +1,5 @@
 gene_name
+AIP
 ALK
 APC
 ATM


### PR DESCRIPTION
# Update to hereditary cancers gene list
In this pull request, we added _AIP_ to our list of genes associated with inherited cancer risk due to studies such as [Marques et al. 2020](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7137887/). 

Additions:
- _AIP_ to hereditary cancers gene list

Pre-pull request check list,
- [x] Relevant documentation has been updated
- [x] All unit tests pass
- [x] All outputs pre- and post- changes match by md5 hash
- [x] All files changed have been reviewed
