### PR TITLE
Updated moalmanac db to 2024-04-11 release

### DIFF
--- a/moalmanac/config.ini
+++ b/moalmanac/config.ini
@@ -9,7 +9,7 @@ plot_preclinical_efficacy = on
 
 [versions]
 interpreter = 0.6.0
-database = v.2023-11-09
+database = v.2024-04-11
 
 [exac]
 exac_common_af_threshold = 0.001

--- a/moalmanac/datasources/moalmanac/README.md
+++ b/moalmanac/datasources/moalmanac/README.md
@@ -7,12 +7,14 @@ The Molecular Oncology Almanac attempts to capture the current body of knowledge
 Several other services exist within the Molecular Oncology Almanac ecosystem. See [this repository's docs folder](/docs/) for more information.
 
 ## Usage: Formatting the database for use
-This method uses a document-based format of the database, which is built using the [database repository](https://github.com/vanallenlab/moalmanac-db) and `create_almanac_db.py`. If MOAlmanac is updated, **please also regenerate [preclinical datasources](../preclinical/)**.
+This method uses a json-based format of the database, which is built using the [database repository](https://github.com/vanallenlab/moalmanac-db) and `create_almanac_db.py`. If MOAlmanac is updated, **please also regenerate [preclinical datasources](../preclinical/)**.
 
 Arguments:
 ```
-    --directory, -d     <string>    path to the moalmanac-db repository's content folder
-    --version, -v       <string>    release name for the database content being used, should match the release from moalmanac-db
+    --config, -c        <string>    path to config.ini file, "../../config.ini" by default
+    --file, -f          <string>    path to moalmanac-db json file
+    --release, -r       <string>    date of moalmanac-db release, should match the release from moalmanac-db
+    --version, -v       <string>    database version of the moalmanac-db schema
 ```
 
 This should be run with this repository's virtual environment enabled. 

--- a/moalmanac/datasources/moalmanac/create_almanac_db.py
+++ b/moalmanac/datasources/moalmanac/create_almanac_db.py
@@ -3,25 +3,6 @@ import configparser
 import json
 import sys
 
-
-def create_config():
-    config = configparser.ConfigParser()
-    config.read('../../config.ini')
-    return config
-
-
-CONFIG = create_config()
-feature_type_section = 'feature_types'
-FEATURE_TYPE_SOMATIC = CONFIG[feature_type_section]['mut']
-FEATURE_TYPE_GERMLINE = CONFIG[feature_type_section]['germline']
-FEATURE_TYPE_COPY_NUMBER = CONFIG[feature_type_section]['cna']
-FEATURE_TYPE_FUSION = CONFIG[feature_type_section]['fusion']
-FEATURE_TYPE_MUTATIONAL_BURDEN = CONFIG[feature_type_section]['burden']
-FEATURE_TYPE_MUTATIONAL_SIGNATURE = CONFIG[feature_type_section]['signature']
-FEATURE_TYPE_MICROSATELLITE_STABILITY = CONFIG[feature_type_section]['microsatellite']
-FEATURE_TYPE_ANEUPLOIDY = CONFIG[feature_type_section]['aneuploidy']
-FEATURE_TYPE_KNOCKDOWN = CONFIG[feature_type_section]['knockdown']
-
 ASSERTION_FIELDS = [
     'disease', 'context', 'oncotree_term', 'oncotree_code',
     'therapy_name', 'therapy_strategy', 'therapy_type',
@@ -135,28 +116,45 @@ class DisplayAlteration:
             return f"{gene}"
 
     @classmethod
-    def generate(cls, record):
+    def generate(cls, record, config_dictionary):
+        feature_type_dictionary = generate_feature_type_string_lookup_dictionary(config_dictionary)
         feature_type = record['feature_type']
-        if feature_type == FEATURE_TYPE_SOMATIC:
+        if feature_type == feature_type_dictionary['somatic_variants']:
             return cls.somatic_variant(record)
-        elif feature_type == FEATURE_TYPE_GERMLINE:
+        elif feature_type == feature_type_dictionary['germline_variants']:
             return cls.germline_variant(record)
-        elif feature_type == FEATURE_TYPE_COPY_NUMBER:
+        elif feature_type == feature_type_dictionary['copy_number_alterations']:
             return cls.copy_number(record)
-        elif feature_type == FEATURE_TYPE_FUSION:
+        elif feature_type == feature_type_dictionary['fusions']:
             return cls.rearrangements(record)
-        elif feature_type == FEATURE_TYPE_ANEUPLOIDY:
+        elif feature_type == feature_type_dictionary['aneuploidy']:
             return cls.aneuploidy(record)
-        elif feature_type == FEATURE_TYPE_MUTATIONAL_BURDEN:
+        elif feature_type == feature_type_dictionary['tmb']:
             return cls.mutational_burden(record)
-        elif feature_type == FEATURE_TYPE_MICROSATELLITE_STABILITY:
+        elif feature_type == feature_type_dictionary['microsatellite']:
             return cls.microsatellite_stability(record)
-        elif feature_type == FEATURE_TYPE_MUTATIONAL_SIGNATURE:
+        elif feature_type == feature_type_dictionary['signature']:
             return cls.cosmic_mutational_signature(record)
-        elif feature_type == FEATURE_TYPE_KNOCKDOWN:
+        elif feature_type == feature_type_dictionary['knockdown']:
             return cls.knockdown(record)
         else:
             print(f'ERROR: {feature_type} does not have a feature display format function.')
+
+
+def generate_feature_type_string_lookup_dictionary(config):
+    feature_type_section = 'feature_types'
+    dictionary = {
+        'somatic_variants': config[feature_type_section]['mut'],
+        'germline_variants': config[feature_type_section]['germline'],
+        'copy_number_alterations': config[feature_type_section]['cna'],
+        'fusions': config[feature_type_section]['fusion'],
+        'tmb': config[feature_type_section]['burden'],
+        'signature': config[feature_type_section]['signature'],
+        'microsatellite': config[feature_type_section]['microsatellite'],
+        'aneuploidy': config[feature_type_section]['aneuploidy'],
+        'knockdown': config[feature_type_section]['knockdown'],
+    }
+    return dictionary
 
 
 def check_fields(fields, record):
@@ -165,12 +163,12 @@ def check_fields(fields, record):
             sys.exit(f'{field} not present in record.\n{record}')
 
 
-def check_format(record):
+def check_format(record, config_dictionary):
     check_fields(SOURCE_FIELDS, record)
     check_fields(ASSERTION_FIELDS, record)
 
     feature_type = record['feature_type']
-    feature_type_fields = get_feature_type_fields(feature_type)
+    feature_type_fields = get_feature_type_fields(feature_type, config_dictionary)
     check_fields(feature_type_fields, record)
 
 
@@ -186,24 +184,25 @@ def extract_genes(records):
     return genes_sorted
 
 
-def get_feature_type_fields(feature_type):
-    if feature_type == FEATURE_TYPE_SOMATIC:
+def get_feature_type_fields(feature_type, config_dictionary):
+    feature_type_dictionary = generate_feature_type_string_lookup_dictionary(config_dictionary)
+    if feature_type == feature_type_dictionary['somatic_variants']:
         return VARIANT_FIELDS
-    elif feature_type == FEATURE_TYPE_GERMLINE:
+    elif feature_type == feature_type_dictionary['germline_variants']:
         return GERMLINE_FIELDS
-    elif feature_type == FEATURE_TYPE_COPY_NUMBER:
+    elif feature_type == feature_type_dictionary['copy_number_alterations']:
         return COPY_NUMBER_FIELDS
-    elif feature_type == FEATURE_TYPE_FUSION:
+    elif feature_type == feature_type_dictionary['fusions']:
         return REARRANGEMENT_FIELDS
-    elif feature_type == FEATURE_TYPE_MUTATIONAL_BURDEN:
+    elif feature_type == feature_type_dictionary['tmb']:
         return MUTATIONAL_BURDEN_FIELDS
-    elif feature_type == FEATURE_TYPE_MUTATIONAL_SIGNATURE:
+    elif feature_type == feature_type_dictionary['signature']:
         return MUTATIONAL_SIGNATURE_FIELDS
-    elif feature_type == FEATURE_TYPE_MICROSATELLITE_STABILITY:
+    elif feature_type == feature_type_dictionary['microsatellite']:
         return MICROSATELLITE_FIELDS
-    elif feature_type == FEATURE_TYPE_ANEUPLOIDY:
+    elif feature_type == feature_type_dictionary['aneuploidy']:
         return ANEUPLOIDY_FIELDS
-    elif feature_type == FEATURE_TYPE_KNOCKDOWN:
+    elif feature_type == feature_type_dictionary['knockdown']:
         return KNOCKDOWN_FIELDS
     else:
         sys.exit(f'feature type {feature_type} present in database but not accounted for.')
@@ -218,6 +217,12 @@ def initialize():
     }
 
 
+def load_config(file_path):
+    config = configparser.ConfigParser()
+    config.read(file_path)
+    return config
+
+
 def load_json(json_file):
     with open(json_file, 'r') as f:
         json_data = json.load(f)
@@ -229,7 +234,7 @@ def write_json(file, data):
         json.dump(data, f, ensure_ascii=False, indent=4)
 
 
-def main(version, release, content):
+def main(version, release, content, config):
     db = initialize()
     db['release'] = release
     db['version'] = version
@@ -238,23 +243,48 @@ def main(version, release, content):
     db['genes'] = db_genes
 
     for record in content:
-        check_format(record)
-        record['feature_display'] = DisplayAlteration.generate(record)
+        if record['_deprecated']:
+            continue
+        check_format(record, config)
+        record['feature_display'] = DisplayAlteration.generate(record, config)
     db['content'] = content
     write_json('molecular-oncology-almanac.json', db)
 
 
 if __name__ == "__main__":
-    arg_parser = argparse.ArgumentParser(prog='Create Molecular Oncology Almanac datasource',
-                                         description='Compiles MOAlmanac db for use with algorithm')
-    arg_parser.add_argument('--file', '-f',
-                            help='Molecular Oncology Almanac db file from https://github.com/vanallenlab/moalmanac-db')
-    arg_parser.add_argument('--version', '-v',
-                            help='Database version; e.g. 1.0.0')
-    arg_parser.add_argument('--release', '-r',
-                            help='Database content release; e.g. v.2022-12-01')
+    arg_parser = argparse.ArgumentParser(
+        prog='Create Molecular Oncology Almanac datasource',
+        description='Compiles MOAlmanac db for use with algorithm'
+    )
+    arg_parser.add_argument(
+        '--config',
+        '-c',
+        help='MOAlmanac configuration file',
+        default='../../config.ini'
+    )
+    arg_parser.add_argument(
+        '--file',
+        '-f',
+        help='Molecular Oncology Almanac db file from https://github.com/vanallenlab/moalmanac-db'
+    )
+    arg_parser.add_argument(
+        '--version',
+        '-v',
+        help='Database version; e.g. 1.0.0'
+    )
+    arg_parser.add_argument(
+        '--release',
+        '-r',
+        help='Database content release; e.g. v.2022-12-01'
+    )
     args = arg_parser.parse_args()
     print(args)
 
     moalmanac_json = load_json(args.file)
-    main(args.version, args.release, moalmanac_json)
+    config_ini = load_config(args.config)
+    main(
+        version=args.version,
+        release=args.release,
+        content=moalmanac_json,
+        config=config_ini
+    )

--- a/moalmanac/datasources/moalmanac/create_almanac_db.py
+++ b/moalmanac/datasources/moalmanac/create_almanac_db.py
@@ -268,14 +268,14 @@ if __name__ == "__main__":
         help='Molecular Oncology Almanac db file from https://github.com/vanallenlab/moalmanac-db'
     )
     arg_parser.add_argument(
-        '--version',
-        '-v',
-        help='Database version; e.g. 1.0.0'
-    )
-    arg_parser.add_argument(
         '--release',
         '-r',
         help='Database content release; e.g. v.2022-12-01'
+    )
+    arg_parser.add_argument(
+        '--version',
+        '-v',
+        help='Database version; e.g. 1.0.0'
     )
     args = arg_parser.parse_args()
     print(args)

--- a/moalmanac/datasources/moalmanac/molecular-oncology-almanac.json
+++ b/moalmanac/datasources/moalmanac/molecular-oncology-almanac.json
@@ -1,6 +1,6 @@
 {
-    "release": "v.2023-11-09",
-    "version": "1.0.2",
+    "release": "2024-04-11",
+    "version": "1.3.0",
     "genes": [
         "ABL1",
         "AKT1",
@@ -181,6 +181,7 @@
             "nct": "",
             "publication_date": "2021-05-01",
             "last_updated": "2021-09-16",
+            "_deprecated": false,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -209,6 +210,7 @@
             "nct": "",
             "publication_date": "2018-12-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -237,6 +239,7 @@
             "nct": "",
             "publication_date": "2018-12-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -265,6 +268,7 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -293,6 +297,7 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -321,6 +326,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -349,6 +355,7 @@
             "nct": "NCT00471497",
             "publication_date": "2010-06-17",
             "last_updated": "2019-08-14",
+            "_deprecated": false,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -377,6 +384,7 @@
             "nct": "",
             "publication_date": "2021-10-01",
             "last_updated": "2021-11-03",
+            "_deprecated": false,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -405,6 +413,7 @@
             "nct": "NCT02075840",
             "publication_date": "2018-06-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "ALK Fusion"
         },
         {
@@ -424,15 +433,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "The U.S. Food and Drug Administration (FDA) granted approval for crizotinib for patients with ALK positive metastatic non-small cell lung cancer (NSCLC) as detected by an FDA-approved test.",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval for crizotinib for the treatment of patients with ALK positive metastatic non-small cell lung cancer (NSCLC) as detected by an FDA-approved test.",
             "source_type": "FDA",
-            "citation": "Pfizer, Inc. Xalkori (crizotinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2019/202570s028lbl.pdf. Revised June 2016. Accessed November 12, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2019/202570s028lbl.pdf",
+            "citation": "Pfizer, Inc. Xalkori (crizotinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2011/202570s000lbl.pdf. Revised August 2011. Accessed March 4, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2011/202570s000lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2016-06-01",
-            "last_updated": "2020-11-12",
+            "publication_date": "2011-08-26",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
             "feature_display": "ALK Fusion"
         },
         {
@@ -461,6 +471,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "ALK Fusion"
         },
         {
@@ -489,6 +500,7 @@
             "nct": "",
             "publication_date": "2019-03-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "ALK"
         },
         {
@@ -517,6 +529,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ALK Fusion"
         },
         {
@@ -545,6 +558,7 @@
             "nct": "NCT01283516",
             "publication_date": "2014-03-27",
             "last_updated": "2019-08-10",
+            "_deprecated": false,
             "feature_display": "ALK"
         },
         {
@@ -573,6 +587,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ALK Translocation"
         },
         {
@@ -601,6 +616,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ALK Translocation"
         },
         {
@@ -629,6 +645,7 @@
             "nct": "NCT00585195",
             "publication_date": "2010-10-28",
             "last_updated": "2019-08-10",
+            "_deprecated": false,
             "feature_display": "ALK Translocation"
         },
         {
@@ -657,6 +674,7 @@
             "nct": "",
             "publication_date": "2010-09-24",
             "last_updated": "2018-09-14",
+            "_deprecated": false,
             "feature_display": "BRD4 Translocation"
         },
         {
@@ -685,6 +703,7 @@
             "nct": "",
             "publication_date": "2016-08-17",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CCND1 Translocation"
         },
         {
@@ -713,6 +732,7 @@
             "nct": "",
             "publication_date": "2013-03-17",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CCND1 Translocation"
         },
         {
@@ -741,6 +761,7 @@
             "nct": "",
             "publication_date": "2016-08-17",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CCND3 Translocation"
         },
         {
@@ -769,6 +790,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "COL1A1--PDGFB Fusion"
         },
         {
@@ -797,6 +819,7 @@
             "nct": "",
             "publication_date": "2023-10-01",
             "last_updated": "2019-08-09",
+            "_deprecated": false,
             "feature_display": "EML4--ALK Fusion"
         },
         {
@@ -825,6 +848,7 @@
             "nct": "",
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "EML4--ALK Fusion"
         },
         {
@@ -853,6 +877,7 @@
             "nct": "",
             "publication_date": "2010-06-06",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "ESRP1--RAF1 Fusion"
         },
         {
@@ -881,6 +906,7 @@
             "nct": "",
             "publication_date": "2010-06-06",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "ESRP1--RAF1 Fusion"
         },
         {
@@ -909,6 +935,7 @@
             "nct": "",
             "publication_date": "2017-01-01",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "EWSR1--FLI1 Fusion"
         },
         {
@@ -937,35 +964,8 @@
             "nct": "",
             "publication_date": "2014-02-13",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "FGFR2--TACC3 Fusion"
-        },
-        {
-            "feature_type": "Rearrangement",
-            "gene1": "FGFR2",
-            "gene2": "",
-            "rearrangement_type": "Fusion",
-            "locus": "",
-            "disease": "Urothelial carcinoma",
-            "context": "Locally advanced or metastatic, progressed during or following at least one line of prior platinum containing chemotherapy including within 12 months of neoadjuvant or adjuvant platinum containing chemotherapy.",
-            "oncotree_term": "Bladder Urothelial Carcinoma",
-            "oncotree_code": "BLCA",
-            "therapy_name": "Erdafitinib",
-            "therapy_strategy": "FGFR inhibition",
-            "therapy_type": "Targeted therapy",
-            "therapy_sensitivity": 1,
-            "therapy_resistance": "",
-            "favorable_prognosis": "",
-            "predictive_implication": "FDA-Approved",
-            "description": "The U.S. Food and Drug Administration (FDA) has granted approval to Balversa (erdafitinib) for the treatment of adult patients with locally advanced or metastatic urothelial carcinoma that has susceptible FGFR3 or FGFR2 genetic alterations, and has progressed during or following at least one line of prior platinum-containing chemotherapy including within 12 months of neoadjuvant or adjuvant platinum-containing chemotherapy.",
-            "source_type": "FDA",
-            "citation": "Janssen Products, LP. Balversa (erdafitinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125427s108lbl.pdf. Revised April 2020. Accessed November 12th, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125427s108lbl.pdf",
-            "doi": "",
-            "pmid": "",
-            "nct": "",
-            "publication_date": "2020-04-01",
-            "last_updated": "2020-11-12",
-            "feature_display": "FGFR2 Fusion"
         },
         {
             "feature_type": "Rearrangement",
@@ -984,7 +984,7 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "The U.S. Food and Drug Administraton (FDA) granted accelerated approval to Pemazyre (pemigatinib). Pemigatinib is a kinase inhibitor indicated for the treatment of adults with previously treated, unresctable locally advanced or metastatic cholangiocarcinoma with a fibroblast growth factor 2 (FGFR2) fusion or rearrangement as detected by an FDA-approved test.",
+            "description": "The U.S. Food and Drug Administraton (FDA) granted accelerated approval to Pemazyre (pemigatinib). Pemigatinib is a kinase inhibitor indicated for the treatment of adults with previously treated, unresectable locally advanced or metastatic cholangiocarcinoma with a fibroblast growth factor 2 (FGFR2) fusion or rearrangement as detected by an FDA-approved test.",
             "source_type": "FDA",
             "citation": "Incyte Corporation. Pemazyre (pemigatinib) [package insert]. U.S. Food and Drug Administration website. www.accessdata.fda.gov/drugsatfda_docs/label/2020/213736s000lbl.pdf. Revised April 2020. Accessed October 15th, 2020.",
             "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/213736s000lbl.pdf",
@@ -993,6 +993,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "FGFR2 Fusion"
         },
         {
@@ -1012,7 +1013,7 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "The U.S. Food and Drug Administraton (FDA) granted accelerated approval to Pemazyre (pemigatinib). Pemigatinib is a kinase inhibitor indicated for the treatment of adults with previously treated, unresctable locally advanced or metastatic cholangiocarcinoma with a fibroblast growth factor 2 (FGFR2) fusion or rearrangement as detected by an FDA-approved test.",
+            "description": "The U.S. Food and Drug Administraton (FDA) granted accelerated approval to Pemazyre (pemigatinib). Pemigatinib is a kinase inhibitor indicated for the treatment of adults with previously treated, unresectable locally advanced or metastatic cholangiocarcinoma with a fibroblast growth factor 2 (FGFR2) fusion or rearrangement as detected by an FDA-approved test.",
             "source_type": "FDA",
             "citation": "Incyte Corporation. Pemazyre (pemigatinib) [package insert]. U.S. Food and Drug Administration website. www.accessdata.fda.gov/drugsatfda_docs/label/2020/213736s000lbl.pdf. Revised April 2020. Accessed October 15th, 2020.",
             "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/213736s000lbl.pdf",
@@ -1021,6 +1022,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "FGFR2"
         },
         {
@@ -1049,6 +1051,7 @@
             "nct": "",
             "publication_date": "2021-05-01",
             "last_updated": "2021-06-01",
+            "_deprecated": false,
             "feature_display": "FGFR2 Fusion"
         },
         {
@@ -1058,7 +1061,7 @@
             "rearrangement_type": "Fusion",
             "locus": "",
             "disease": "Urothelial carcinoma",
-            "context": "Locally advanced or metastatic, progressed during or following at least one line of prior platinum containing chemotherapy including within 12 months of neoadjuvant or adjuvant platinum containing chemotherapy.",
+            "context": "Locally advanced or metastatic.",
             "oncotree_term": "Bladder Urothelial Carcinoma",
             "oncotree_code": "BLCA",
             "therapy_name": "Erdafitinib",
@@ -1068,15 +1071,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "Erdafitinib is indictated for the treatment of adult patients with locally advanced or metastatic urothelial carcinoma that has susceptible FGFR3 or FGFR2 genetic alterations, and has progressed during or following at least one line of prior platinum-containing chemotherapy including within 12 months of neoadjuvant or adjuvant platinum-containing chemotherapy.",
+            "description": "The U.S. Food and Drug Administration (FDA) has granted approval to erdafitinib for the treatment of adult patients with locally advanced or metastatic urothelial carcinoma with susceptible FGFR3 genetic alterations, and has progressed during or following at least one line of systemic therapy, as determined by an FDA-approved companion diagnostic. Erdafitinib is not recommended for the treatment of patients who are eligible for and have not received prior PD-1 or PD-L1 inhibitor therapy.",
             "source_type": "FDA",
-            "citation": "Janssen Products, LP. Balversa (erdafitinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125427s108lbl.pdf. Revised April 2020. Accessed November 12, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125427s108lbl.pdf",
+            "citation": "Janssen Products, LP. Balversa (erdafitinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/212018s007s008s009lbl.pdf. Revised January 2024. Accessed January 25, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/212018s007s008s009lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-04-01",
-            "last_updated": "2020-11-12",
+            "publication_date": "2024-01-19",
+            "last_updated": "2024-01-25",
+            "_deprecated": false,
             "feature_display": "FGFR3 Fusion"
         },
         {
@@ -1105,6 +1109,7 @@
             "nct": "",
             "publication_date": "2013-05-16",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "FGFR3--NSD2 Fusion"
         },
         {
@@ -1133,6 +1138,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "IGH Translocation"
         },
         {
@@ -1161,13 +1167,14 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "IGH Translocation"
         },
         {
             "feature_type": "Rearrangement",
             "gene1": "NTRK1",
             "gene2": "",
-            "rearrangement_type": "Translocation",
+            "rearrangement_type": "Fusion",
             "locus": "",
             "disease": "Any solid tumor",
             "context": "",
@@ -1189,7 +1196,8 @@
             "nct": "NCT02122913",
             "publication_date": "2018-11-01",
             "last_updated": "2020-11-12",
-            "feature_display": "NTRK1 Translocation"
+            "_deprecated": false,
+            "feature_display": "NTRK1 Fusion"
         },
         {
             "feature_type": "Rearrangement",
@@ -1217,6 +1225,7 @@
             "nct": "",
             "publication_date": "2016-03-18",
             "last_updated": "2017-03-16",
+            "_deprecated": false,
             "feature_display": "NTRK1 Fusion"
         },
         {
@@ -1245,13 +1254,14 @@
             "nct": "",
             "publication_date": "2023-10-20",
             "last_updated": "2023-11-01",
+            "_deprecated": false,
             "feature_display": "NTRK1 Fusion"
         },
         {
             "feature_type": "Rearrangement",
             "gene1": "NTRK2",
             "gene2": "",
-            "rearrangement_type": "Translocation",
+            "rearrangement_type": "Fusion",
             "locus": "",
             "disease": "Any solid tumor",
             "context": "",
@@ -1273,7 +1283,8 @@
             "nct": "NCT02122913",
             "publication_date": "2018-11-01",
             "last_updated": "2020-11-12",
-            "feature_display": "NTRK2 Translocation"
+            "_deprecated": false,
+            "feature_display": "NTRK2 Fusion"
         },
         {
             "feature_type": "Rearrangement",
@@ -1301,6 +1312,7 @@
             "nct": "",
             "publication_date": "2016-03-18",
             "last_updated": "2017-03-16",
+            "_deprecated": false,
             "feature_display": "NTRK2 Fusion"
         },
         {
@@ -1329,13 +1341,14 @@
             "nct": "",
             "publication_date": "2023-10-20",
             "last_updated": "2023-11-01",
+            "_deprecated": false,
             "feature_display": "NTRK2 Fusion"
         },
         {
             "feature_type": "Rearrangement",
             "gene1": "NTRK3",
             "gene2": "",
-            "rearrangement_type": "Translocation",
+            "rearrangement_type": "Fusion",
             "locus": "",
             "disease": "Any solid tumor",
             "context": "",
@@ -1357,7 +1370,8 @@
             "nct": "NCT02122913",
             "publication_date": "2018-11-01",
             "last_updated": "2020-11-12",
-            "feature_display": "NTRK3 Translocation"
+            "_deprecated": false,
+            "feature_display": "NTRK3 Fusion"
         },
         {
             "feature_type": "Rearrangement",
@@ -1385,6 +1399,7 @@
             "nct": "",
             "publication_date": "2016-03-18",
             "last_updated": "2017-03-16",
+            "_deprecated": false,
             "feature_display": "NTRK3 Fusion"
         },
         {
@@ -1413,6 +1428,7 @@
             "nct": "",
             "publication_date": "2023-10-20",
             "last_updated": "2023-11-01",
+            "_deprecated": false,
             "feature_display": "NTRK3 Fusion"
         },
         {
@@ -1441,6 +1457,7 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "PDGFRA"
         },
         {
@@ -1469,6 +1486,7 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "FIP1L1--PDGFRA Fusion"
         },
         {
@@ -1497,6 +1515,7 @@
             "nct": "",
             "publication_date": "2003-08-23",
             "last_updated": "2019-03-19",
+            "_deprecated": false,
             "feature_display": "BCR--PDGFRA Fusion"
         },
         {
@@ -1525,6 +1544,7 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "PDGFRB"
         },
         {
@@ -1553,6 +1573,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ETV6--PDGFRB Fusion"
         },
         {
@@ -1581,6 +1602,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "RET"
         },
         {
@@ -1609,6 +1631,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "RET"
         },
         {
@@ -1637,6 +1660,7 @@
             "nct": "NCT01639508",
             "publication_date": "2013-06-06",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "RET Fusion"
         },
         {
@@ -1665,6 +1689,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "RET Fusion"
         },
         {
@@ -1693,6 +1718,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "RET Fusion"
         },
         {
@@ -1721,6 +1747,7 @@
             "nct": "",
             "publication_date": "2023-08-09",
             "last_updated": "2023-09-06",
+            "_deprecated": false,
             "feature_display": "RET Fusion"
         },
         {
@@ -1749,6 +1776,7 @@
             "nct": "",
             "publication_date": "2020-12-01",
             "last_updated": "2020-12-03",
+            "_deprecated": false,
             "feature_display": "RET Fusion"
         },
         {
@@ -1768,15 +1796,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "The U.S. Food and Drug Administration (FDA) granted approval for crizotinib for patients with ROS positive metastatic non-small cell lung cancer (NSCLC).",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval for crizotinib for the treatment of patients with ROS positive metastatic non-small cell lung cancer (NSCLC).",
             "source_type": "FDA",
-            "citation": "Pfizer, Inc. Xalkori (crizotinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2019/202570s028lbl.pdf. Revised June 2016. Accessed November 12, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2019/202570s028lbl.pdf",
+            "citation": "Pfizer, Inc. Xalkori (crizotinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2016/202570s016lbl.pdf. Revised March 2016. Accessed March 4, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2016/202570s016lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2016-06-01",
-            "last_updated": "2020-11-12",
+            "publication_date": "2016-03-11",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
             "feature_display": "ROS1 Fusion"
         },
         {
@@ -1805,7 +1834,7 @@
             "nct": "",
             "publication_date": "2019-08-01",
             "last_updated": "2020-11-12",
-            "feature_display": "ROS1 Fusion"
+            "_deprecated": true
         },
         {
             "feature_type": "Rearrangement",
@@ -1833,6 +1862,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "RUNX1--RUNX1T1 Fusion"
         },
         {
@@ -1861,6 +1891,7 @@
             "nct": "",
             "publication_date": "2010-06-06",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "SLC45A3--BRAF Fusion"
         },
         {
@@ -1889,6 +1920,7 @@
             "nct": "",
             "publication_date": "2010-06-06",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "SLC45A3--BRAF Fusion"
         },
         {
@@ -1917,6 +1949,7 @@
             "nct": "",
             "publication_date": "2013-04-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "TMPRSS2--ERG Fusion"
         },
         {
@@ -1945,6 +1978,7 @@
             "nct": "",
             "publication_date": "2007-01-22",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "TMPRSS2--ERG Fusion"
         },
         {
@@ -1973,6 +2007,7 @@
             "nct": "NCT01576172",
             "publication_date": "2017-12-20",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "TMPRSS2--ERG Fusion"
         },
         {
@@ -2001,21 +2036,22 @@
             "nct": "NCT01576172",
             "publication_date": "2017-12-20",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "TMPRSS2--ERG Fusion"
         },
         {
             "feature_type": "Somatic Variant",
             "gene": "ABL1",
             "chromosome": "9",
-            "start_position": 133747580,
-            "end_position": 133747580,
+            "start_position": 133748283,
+            "end_position": 133748283,
             "reference_allele": "C",
             "alternate_allele": "T",
             "cdna_change": "c.944C>T",
             "protein_change": "p.T315I",
             "variant_annotation": "Missense",
             "exon": 5,
-            "rsid": "",
+            "rsid": "rs121913459",
             "disease": "Chronic Myeloid Leukemia",
             "context": "",
             "oncotree_term": "Chronic Myelogenous Leukemia",
@@ -2035,7 +2071,8 @@
             "pmid": 11423618,
             "nct": "",
             "publication_date": "2001-06-21",
-            "last_updated": "2019-06-13",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "ABL1 p.T315I (Missense)"
         },
         {
@@ -2071,6 +2108,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "ABL1 (Missense)"
         },
         {
@@ -2106,21 +2144,22 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ABL1 p.T315A (Missense)"
         },
         {
             "feature_type": "Somatic Variant",
             "gene": "ABL1",
             "chromosome": "9",
-            "start_position": 133747580,
-            "end_position": 133747580,
+            "start_position": 133748283,
+            "end_position": 133748283,
             "reference_allele": "C",
             "alternate_allele": "T",
             "cdna_change": "c.944C>T",
             "protein_change": "p.T315I",
             "variant_annotation": "Missense",
             "exon": 5,
-            "rsid": "",
+            "rsid": "rs121913459",
             "disease": "Chronic Myeloid Leukemia",
             "context": "",
             "oncotree_term": "Chronic Myelogenous Leukemia",
@@ -2140,7 +2179,8 @@
             "pmid": 27760149,
             "nct": "",
             "publication_date": "2011-08-04",
-            "last_updated": "2019-06-13",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "ABL1 p.T315I (Missense)"
         },
         {
@@ -2176,6 +2216,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F317L (Missense)"
         },
         {
@@ -2211,6 +2252,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F317V (Missense)"
         },
         {
@@ -2246,6 +2288,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F317I (Missense)"
         },
         {
@@ -2281,6 +2324,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F317C (Missense)"
         },
         {
@@ -2316,6 +2360,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "ABL1"
         },
         {
@@ -2351,6 +2396,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ABL1 p.E255K (Missense)"
         },
         {
@@ -2386,6 +2432,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ABL1 p.E255V (Missense)"
         },
         {
@@ -2421,6 +2468,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ABL1 p.Y253H (Missense)"
         },
         {
@@ -2456,6 +2504,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F359V (Missense)"
         },
         {
@@ -2491,6 +2540,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F359C (Missense)"
         },
         {
@@ -2526,6 +2576,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F359I (Missense)"
         },
         {
@@ -2561,6 +2612,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.Y253H (Missense)"
         },
         {
@@ -2596,6 +2648,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.E255K (Missense)"
         },
         {
@@ -2631,6 +2684,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.E255V (Missense)"
         },
         {
@@ -2666,6 +2720,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F359V (Missense)"
         },
         {
@@ -2701,6 +2756,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F359C (Missense)"
         },
         {
@@ -2736,6 +2792,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F359I (Missense)"
         },
         {
@@ -2771,6 +2828,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F317L (Missense)"
         },
         {
@@ -2806,6 +2864,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F317V (Missense)"
         },
         {
@@ -2841,6 +2900,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F317I (Missense)"
         },
         {
@@ -2876,6 +2936,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F317C (Missense)"
         },
         {
@@ -2911,6 +2972,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.T315A (Missense)"
         },
         {
@@ -2946,6 +3008,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.V299L (Missense)"
         },
         {
@@ -2981,6 +3044,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.E255K (Missense)"
         },
         {
@@ -3016,6 +3080,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.E255V (Missense)"
         },
         {
@@ -3051,6 +3116,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F317L (Missense)"
         },
         {
@@ -3086,6 +3152,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F317V (Missense)"
         },
         {
@@ -3121,6 +3188,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F317I (Missense)"
         },
         {
@@ -3156,6 +3224,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F317C (Missense)"
         },
         {
@@ -3191,6 +3260,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F359V (Missense)"
         },
         {
@@ -3226,6 +3296,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F359C (Missense)"
         },
         {
@@ -3261,6 +3332,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.T315A (Missense)"
         },
         {
@@ -3296,6 +3368,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.Y253H (Missense)"
         },
         {
@@ -3309,8 +3382,8 @@
             "cdna_change": "c.944C>T",
             "protein_change": "p.T315I",
             "variant_annotation": "Missense",
-            "exon": 6,
-            "rsid": "",
+            "exon": 5,
+            "rsid": "rs121913459",
             "disease": "Chronic Myeloid Leukemia",
             "context": "",
             "oncotree_term": "Chronic Myelogenous Leukemia",
@@ -3330,7 +3403,8 @@
             "pmid": "",
             "nct": "",
             "publication_date": "2016-01-01",
-            "last_updated": "2023-11-02",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "ABL1 p.T315I (Missense)"
         },
         {
@@ -3344,8 +3418,8 @@
             "cdna_change": "c.944C>T",
             "protein_change": "p.T315I",
             "variant_annotation": "Missense",
-            "exon": 6,
-            "rsid": "",
+            "exon": 5,
+            "rsid": "rs121913459",
             "disease": "Chronic Myeloid Leukemia",
             "context": "",
             "oncotree_term": "Chronic Myelogenous Leukemia",
@@ -3365,7 +3439,8 @@
             "pmid": "",
             "nct": "",
             "publication_date": "2016-01-01",
-            "last_updated": "2023-11-02",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "ABL1 p.T315I (Missense)"
         },
         {
@@ -3401,6 +3476,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ABL1 p.F359I (Missense)"
         },
         {
@@ -3418,8 +3494,8 @@
             "rsid": "",
             "disease": "Breast cancer",
             "context": "",
-            "oncotree_term": "BRCA",
-            "oncotree_code": "Invasive Breast Carcinoma",
+            "oncotree_term": "Invasive Breast Carcinoma",
+            "oncotree_code": "BRCA",
             "therapy_name": "MK-2206",
             "therapy_strategy": "PI3K/AKT/mTOR inhibition",
             "therapy_type": "Targeted therapy",
@@ -3436,6 +3512,7 @@
             "nct": "",
             "publication_date": "2015-11-03",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "AKT1 (Missense)"
         },
         {
@@ -3453,8 +3530,8 @@
             "rsid": "rs34409589",
             "disease": "Breast cancer",
             "context": "",
-            "oncotree_term": "BRCA",
-            "oncotree_code": "Invasive Breast Carcinoma",
+            "oncotree_term": "Invasive Breast Carcinoma",
+            "oncotree_code": "BRCA",
             "therapy_name": "MK-2206",
             "therapy_strategy": "PI3K/AKT/mTOR inhibition",
             "therapy_type": "Targeted therapy",
@@ -3471,6 +3548,7 @@
             "nct": "",
             "publication_date": "2015-11-03",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "AKT1 p.E17K (Missense)"
         },
         {
@@ -3506,6 +3584,7 @@
             "nct": "",
             "publication_date": "2015-11-03",
             "last_updated": "2017-03-16",
+            "_deprecated": false,
             "feature_display": "AKT2 (Missense)"
         },
         {
@@ -3541,6 +3620,7 @@
             "nct": "",
             "publication_date": "2015-11-03",
             "last_updated": "2017-03-16",
+            "_deprecated": false,
             "feature_display": "AKT3 (Missense)"
         },
         {
@@ -3576,6 +3656,7 @@
             "nct": "",
             "publication_date": "2014-06-01",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ALK p.G1202R (Missense)"
         },
         {
@@ -3611,6 +3692,7 @@
             "nct": "",
             "publication_date": "2014-06-01",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ALK p.F1174C (Missense)"
         },
         {
@@ -3646,6 +3728,7 @@
             "nct": "",
             "publication_date": "2014-06-01",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ALK p.L1196M (Missense)"
         },
         {
@@ -3681,6 +3764,7 @@
             "nct": "",
             "publication_date": "2014-06-01",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ALK p.G1269A (Missense)"
         },
         {
@@ -3716,6 +3800,7 @@
             "nct": "",
             "publication_date": "2014-06-01",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ALK p.S1206Y (Missense)"
         },
         {
@@ -3751,6 +3836,7 @@
             "nct": "",
             "publication_date": "2015-03-12",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "AR p.T878A (Missense)"
         },
         {
@@ -3786,6 +3872,7 @@
             "nct": "",
             "publication_date": "2015-03-12",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "AR p.L702H (Missense)"
         },
         {
@@ -3821,6 +3908,7 @@
             "nct": "",
             "publication_date": "2014-02-24",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ARAF p.S214C (Missense)"
         },
         {
@@ -3856,6 +3944,7 @@
             "nct": "",
             "publication_date": "2018-05-07",
             "last_updated": "2019-02-04",
+            "_deprecated": false,
             "feature_display": "ARID1A (Nonsense)"
         },
         {
@@ -3891,6 +3980,7 @@
             "nct": "",
             "publication_date": "2018-05-07",
             "last_updated": "2019-02-04",
+            "_deprecated": false,
             "feature_display": "ARID1A (Frameshift)"
         },
         {
@@ -3926,6 +4016,7 @@
             "nct": "",
             "publication_date": "2015-04-09",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "ARID1A"
         },
         {
@@ -3961,6 +4052,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ASXL1 (Nonsense)"
         },
         {
@@ -3996,6 +4088,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ASXL1 (Frameshift)"
         },
         {
@@ -4022,15 +4115,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "Clinical trial",
-            "description": "The ATR inhibitor BAY 1895344 is tolerated at biologically active doses with anti-tumor activity against cancers with certain DDR defects, including ATM protein loss, in patients with advanced metastatic solid tumors resistant or refractory to standard treatment, with and without DDR defects.",
-            "source_type": "Abstract",
-            "citation": "De Bono JS, Tan DSP, Caldwell R, et al. First-in-human trial of the oral ataxia telangiectasia and Rad3-related (ATR) inhibitor BAY 1895344 in patients (pts) with advanced solid tumors. JCO. 2019; 37(15_suppl):3007-3007.",
-            "url": "https://doi.org/10.1200/JCO.2019.37.15_suppl.3007",
-            "doi": "10.1200/JCO.2019.37.15_suppl.3007",
-            "pmid": "",
-            "nct": "NCT03188965",
-            "publication_date": "2019-05-26",
-            "last_updated": "2023-11-01",
+            "description": "The ATR inhibitor BAY 1895344 was tolerated in a dose-escalation phase 1 trial (NCT03188965) across 21 patients with advanced solid tumors. Responders had ATM protein loss and/or deleterious ATM variants.",
+            "source_type": "Journal",
+            "citation": "Yap TA, Tan DSP, Terbuch A, et al. First-in-Human Trial of the Oral Ataxia Telangiectasia and RAD3-Related (ATR) Inhibitor BAY 1895344 in Patients with Advanced Solid Tumors. Cancer Discovery. 2021;11(1):80-91.",
+            "url": "https://doi.org/10.1158/2159-8290.CD-20-0868",
+            "doi": "10.1158/2159-8290.CD-20-0868",
+            "pmid": "32988960",
+            "nct": "",
+            "publication_date": "2021-01-06",
+            "last_updated": "2024-03-05",
+            "_deprecated": false,
             "feature_display": "ATM (Frameshift)"
         },
         {
@@ -4057,15 +4151,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "Clinical trial",
-            "description": "The ATR inhibitor BAY 1895344 is tolerated at biologically active doses with anti-tumor activity against cancers with certain DDR defects, including ATM protein loss, in patients with advanced metastatic solid tumors resistant or refractory to standard treatment, with and without DDR defects.",
-            "source_type": "Abstract",
-            "citation": "De Bono JS, Tan DSP, Caldwell R, et al. First-in-human trial of the oral ataxia telangiectasia and Rad3-related (ATR) inhibitor BAY 1895344 in patients (pts) with advanced solid tumors. JCO. 2019; 37(15_suppl):3007-3007.",
-            "url": "https://doi.org/10.1200/JCO.2019.37.15_suppl.3007",
-            "doi": "10.1200/JCO.2019.37.15_suppl.3007",
-            "pmid": "",
-            "nct": "NCT03188965",
-            "publication_date": "2019-05-26",
-            "last_updated": "2023-11-01",
+            "description": "The ATR inhibitor BAY 1895344 was tolerated in a dose-escalation phase 1 trial (NCT03188965) across 21 patients with advanced solid tumors. Responders had ATM protein loss and/or deleterious ATM variants.",
+            "source_type": "Journal",
+            "citation": "Yap TA, Tan DSP, Terbuch A, et al. First-in-Human Trial of the Oral Ataxia Telangiectasia and RAD3-Related (ATR) Inhibitor BAY 1895344 in Patients with Advanced Solid Tumors. Cancer Discovery. 2021;11(1):80-91.",
+            "url": "https://doi.org/10.1158/2159-8290.CD-20-0868",
+            "doi": "10.1158/2159-8290.CD-20-0868",
+            "pmid": "32988960",
+            "nct": "",
+            "publication_date": "2021-01-06",
+            "last_updated": "2024-03-05",
+            "_deprecated": false,
             "feature_display": "ATM (Splice Site)"
         },
         {
@@ -4092,15 +4187,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "Clinical trial",
-            "description": "The ATR inhibitor BAY 1895344 is tolerated at biologically active doses with anti-tumor activity against cancers with certain DDR defects, including ATM protein loss, in patients with advanced metastatic solid tumors resistant or refractory to standard treatment, with and without DDR defects.",
-            "source_type": "Abstract",
-            "citation": "De Bono JS, Tan DSP, Caldwell R, et al. First-in-human trial of the oral ataxia telangiectasia and Rad3-related (ATR) inhibitor BAY 1895344 in patients (pts) with advanced solid tumors. JCO. 2019; 37(15_suppl):3007-3007.",
-            "url": "https://doi.org/10.1200/JCO.2019.37.15_suppl.3007",
-            "doi": "10.1200/JCO.2019.37.15_suppl.3007",
-            "pmid": "",
-            "nct": "NCT03188965",
-            "publication_date": "2019-05-26",
-            "last_updated": "2023-11-01",
+            "description": "The ATR inhibitor BAY 1895344 was tolerated in a dose-escalation phase 1 trial (NCT03188965) across 21 patients with advanced solid tumors. Responders had ATM protein loss and/or deleterious ATM variants.",
+            "source_type": "Journal",
+            "citation": "Yap TA, Tan DSP, Terbuch A, et al. First-in-Human Trial of the Oral Ataxia Telangiectasia and RAD3-Related (ATR) Inhibitor BAY 1895344 in Patients with Advanced Solid Tumors. Cancer Discovery. 2021;11(1):80-91.",
+            "url": "https://doi.org/10.1158/2159-8290.CD-20-0868",
+            "doi": "10.1158/2159-8290.CD-20-0868",
+            "pmid": "32988960",
+            "nct": "",
+            "publication_date": "2021-01-06",
+            "last_updated": "2024-03-05",
+            "_deprecated": false,
             "feature_display": "ATM (Nonsense)"
         },
         {
@@ -4136,6 +4232,7 @@
             "nct": "",
             "publication_date": "2016-12-31",
             "last_updated": "2019-08-08",
+            "_deprecated": false,
             "feature_display": "ATM (Frameshift)"
         },
         {
@@ -4171,6 +4268,7 @@
             "nct": "",
             "publication_date": "2016-12-31",
             "last_updated": "2019-08-08",
+            "_deprecated": false,
             "feature_display": "ATM (Splice Site)"
         },
         {
@@ -4206,6 +4304,7 @@
             "nct": "",
             "publication_date": "2016-12-31",
             "last_updated": "2019-08-08",
+            "_deprecated": false,
             "feature_display": "ATM (Nonsense)"
         },
         {
@@ -4241,6 +4340,7 @@
             "nct": "",
             "publication_date": "2017-04-01",
             "last_updated": "2019-08-15",
+            "_deprecated": false,
             "feature_display": "ATM p.A1127D (Missense)"
         },
         {
@@ -4276,6 +4376,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "ATM"
         },
         {
@@ -4311,6 +4412,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -4346,6 +4448,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -4381,6 +4484,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -4416,6 +4520,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -4451,6 +4556,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -4486,6 +4592,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -4521,6 +4628,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -4556,6 +4664,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BCOR (Nonsense)"
         },
         {
@@ -4591,6 +4700,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BCOR (Frameshift)"
         },
         {
@@ -4626,6 +4736,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BCOR (Splice Site)"
         },
         {
@@ -4661,6 +4772,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BCOR p.N1425S (Missense)"
         },
         {
@@ -4696,6 +4808,7 @@
             "nct": "",
             "publication_date": "2011-08-04",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BCR"
         },
         {
@@ -4731,6 +4844,7 @@
             "nct": "",
             "publication_date": "2015-09-11",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "BLM"
         },
         {
@@ -4747,7 +4861,7 @@
             "exon": 15,
             "rsid": "rs113488022",
             "disease": "Melanoma",
-            "context": "Unresctable or metastatic",
+            "context": "Unresectable or metastatic",
             "oncotree_term": "Melanoma",
             "oncotree_code": "MEL",
             "therapy_name": "Dabrafenib",
@@ -4766,6 +4880,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -4782,7 +4897,7 @@
             "exon": 15,
             "rsid": "rs113488022",
             "disease": "Melanoma",
-            "context": "Unresctable or metastatic",
+            "context": "Unresectable or metastatic",
             "oncotree_term": "Melanoma",
             "oncotree_code": "MEL",
             "therapy_name": "Dabrafenib + Trametinib",
@@ -4801,6 +4916,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -4817,7 +4933,7 @@
             "exon": 15,
             "rsid": "rs121913227",
             "disease": "Melanoma",
-            "context": "Unresctable or metastatic",
+            "context": "Unresectable or metastatic",
             "oncotree_term": "Melanoma",
             "oncotree_code": "MEL",
             "therapy_name": "Dabrafenib + Trametinib",
@@ -4836,6 +4952,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600K (Missense)"
         },
         {
@@ -4871,6 +4988,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -4906,6 +5024,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600K (Missense)"
         },
         {
@@ -4941,6 +5060,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -4957,7 +5077,7 @@
             "exon": 15,
             "rsid": "rs113488022",
             "disease": "Melanoma",
-            "context": "Unresctable or metastatic",
+            "context": "Unresectable or metastatic",
             "oncotree_term": "Melanoma",
             "oncotree_code": "MEL",
             "therapy_name": "Trametinib",
@@ -4976,6 +5096,7 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -4992,7 +5113,7 @@
             "exon": 15,
             "rsid": "rs121913227",
             "disease": "Melanoma",
-            "context": "Unresctable or metastatic",
+            "context": "Unresectable or metastatic",
             "oncotree_term": "Melanoma",
             "oncotree_code": "MEL",
             "therapy_name": "Trametinib",
@@ -5011,6 +5132,7 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600K (Missense)"
         },
         {
@@ -5027,7 +5149,7 @@
             "exon": 15,
             "rsid": "rs121913227",
             "disease": "Melanoma",
-            "context": "Unresctable or metastatic",
+            "context": "Unresectable or metastatic",
             "oncotree_term": "Melanoma",
             "oncotree_code": "MEL",
             "therapy_name": "Encorafenib",
@@ -5046,6 +5168,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2021-09-16",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600K (Missense)"
         },
         {
@@ -5062,7 +5185,7 @@
             "exon": 15,
             "rsid": "rs113488022",
             "disease": "Melanoma",
-            "context": "Unresctable or metastatic",
+            "context": "Unresectable or metastatic",
             "oncotree_term": "Melanoma",
             "oncotree_code": "MEL",
             "therapy_name": "Encorafenib",
@@ -5081,6 +5204,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2021-09-16",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5116,6 +5240,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5132,7 +5257,7 @@
             "exon": 15,
             "rsid": "rs113488022",
             "disease": "Melanoma",
-            "context": "Unresctable or metastatic",
+            "context": "Unresectable or metastatic",
             "oncotree_term": "Melanoma",
             "oncotree_code": "MEL",
             "therapy_name": "Vemurafenib",
@@ -5151,6 +5276,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5186,6 +5312,7 @@
             "nct": "",
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5221,6 +5348,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5256,6 +5384,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5291,6 +5420,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5326,6 +5456,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5361,6 +5492,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5396,6 +5528,7 @@
             "nct": "NCT01673854",
             "publication_date": "2016-08-16",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5431,6 +5564,7 @@
             "nct": "NCT01673854",
             "publication_date": "2016-08-16",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5466,6 +5600,7 @@
             "nct": "",
             "publication_date": "2016-06-30",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5501,6 +5636,7 @@
             "nct": "",
             "publication_date": "2016-06-30",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5536,6 +5672,7 @@
             "nct": "",
             "publication_date": "2009-12-1",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRAF"
         },
         {
@@ -5571,6 +5708,7 @@
             "nct": "",
             "publication_date": "2016-10-01",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5606,6 +5744,7 @@
             "nct": "",
             "publication_date": "2017-02-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5641,6 +5780,7 @@
             "nct": "NCT01524978",
             "publication_date": "2015-08-20",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5676,6 +5816,7 @@
             "nct": "NCT01524978",
             "publication_date": "2015-08-20",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5711,6 +5852,7 @@
             "nct": "NCT01524978",
             "publication_date": "2015-08-20",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5746,6 +5888,7 @@
             "nct": "",
             "publication_date": "2016-09-28",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5781,6 +5924,7 @@
             "nct": "",
             "publication_date": "2016-06-02",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5816,6 +5960,7 @@
             "nct": "",
             "publication_date": "2016-06-02",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5851,6 +5996,7 @@
             "nct": "",
             "publication_date": "2016-10-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5886,6 +6032,7 @@
             "nct": "",
             "publication_date": "2014-01-07",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRAF"
         },
         {
@@ -5921,6 +6068,7 @@
             "nct": "",
             "publication_date": "2014-01-07",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRAF"
         },
         {
@@ -5956,6 +6104,7 @@
             "nct": "",
             "publication_date": "2014-01-07",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRAF"
         },
         {
@@ -5991,6 +6140,7 @@
             "nct": "",
             "publication_date": "2014-01-07",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRAF"
         },
         {
@@ -6026,6 +6176,7 @@
             "nct": "",
             "publication_date": "2015-04-09",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -6061,6 +6212,7 @@
             "nct": "",
             "publication_date": "2015-05-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -6096,6 +6248,7 @@
             "nct": "",
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -6131,6 +6284,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -6166,6 +6320,7 @@
             "nct": "NCT01524978",
             "publication_date": "2015-08-20",
             "last_updated": "2019-10-04",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -6201,6 +6356,7 @@
             "nct": "NCT01844986",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6236,6 +6392,7 @@
             "nct": "NCT01844986",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6271,6 +6428,7 @@
             "nct": "NCT01844986",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6283,7 +6441,7 @@
             "alternate_allele": "",
             "cdna_change": "",
             "protein_change": "",
-            "variant_annotation": "Oncogenic Mutations",
+            "variant_annotation": "",
             "exon": "",
             "rsid": "",
             "disease": "Ovarian Cancer",
@@ -6306,7 +6464,8 @@
             "nct": "",
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
-            "feature_display": "BRCA1 (Oncogenic Mutations)"
+            "_deprecated": false,
+            "feature_display": "BRCA1"
         },
         {
             "feature_type": "Somatic Variant",
@@ -6318,12 +6477,12 @@
             "alternate_allele": "",
             "cdna_change": "",
             "protein_change": "",
-            "variant_annotation": "Oncogenic Mutations",
+            "variant_annotation": "",
             "exon": "",
             "rsid": "",
-            "disease": "Ovarian Cancer",
+            "disease": "Fallopian Tube",
             "context": "",
-            "oncotree_term": "Fallopian Tube",
+            "oncotree_term": "High-Grade Serous Fallopian Tube Cancer",
             "oncotree_code": "HGSFT",
             "therapy_name": "Rucaparib",
             "therapy_strategy": "PARP inhibition",
@@ -6341,7 +6500,8 @@
             "nct": "",
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
-            "feature_display": "BRCA1 (Oncogenic Mutations)"
+            "_deprecated": false,
+            "feature_display": "BRCA1"
         },
         {
             "feature_type": "Somatic Variant",
@@ -6353,7 +6513,7 @@
             "alternate_allele": "",
             "cdna_change": "",
             "protein_change": "",
-            "variant_annotation": "Oncogenic Mutations",
+            "variant_annotation": "",
             "exon": "",
             "rsid": "",
             "disease": "Peritoneal cancer",
@@ -6376,7 +6536,8 @@
             "nct": "",
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
-            "feature_display": "BRCA1 (Oncogenic Mutations)"
+            "_deprecated": false,
+            "feature_display": "BRCA1"
         },
         {
             "feature_type": "Somatic Variant",
@@ -6411,6 +6572,7 @@
             "nct": "",
             "publication_date": "2010-04-20",
             "last_updated": "2019-03-20",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6446,6 +6608,7 @@
             "nct": "",
             "publication_date": "2017-02-21",
             "last_updated": "2019-03-20",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6481,6 +6644,7 @@
             "nct": "",
             "publication_date": "2015-02-25",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6516,6 +6680,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6551,6 +6716,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6586,6 +6752,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6621,6 +6788,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6656,6 +6824,7 @@
             "nct": "",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6691,6 +6860,7 @@
             "nct": "",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6726,6 +6896,7 @@
             "nct": "",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -6761,6 +6932,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -6796,6 +6968,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -6831,6 +7004,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -6866,6 +7040,7 @@
             "nct": "NCT01844986",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -6901,6 +7076,7 @@
             "nct": "NCT01844986",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -6936,6 +7112,7 @@
             "nct": "NCT01844986",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -6948,7 +7125,7 @@
             "alternate_allele": "",
             "cdna_change": "",
             "protein_change": "",
-            "variant_annotation": "Oncogenic Mutations",
+            "variant_annotation": "",
             "exon": "",
             "rsid": "",
             "disease": "Ovarian Cancer",
@@ -6971,7 +7148,8 @@
             "nct": "",
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
-            "feature_display": "BRCA2 (Oncogenic Mutations)"
+            "_deprecated": false,
+            "feature_display": "BRCA2"
         },
         {
             "feature_type": "Somatic Variant",
@@ -6983,12 +7161,12 @@
             "alternate_allele": "",
             "cdna_change": "",
             "protein_change": "",
-            "variant_annotation": "Oncogenic Mutations",
+            "variant_annotation": "",
             "exon": "",
             "rsid": "",
-            "disease": "Ovarian Cancer",
+            "disease": "Fallopian Tube",
             "context": "Previously treated with 2 or more chemotherapies",
-            "oncotree_term": "Fallopian Tube",
+            "oncotree_term": "High-Grade Serous Fallopian Tube Cancer",
             "oncotree_code": "HGSFT",
             "therapy_name": "Rucaparib",
             "therapy_strategy": "PARP inhibition",
@@ -7006,7 +7184,8 @@
             "nct": "",
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
-            "feature_display": "BRCA2 (Oncogenic Mutations)"
+            "_deprecated": false,
+            "feature_display": "BRCA2"
         },
         {
             "feature_type": "Somatic Variant",
@@ -7018,7 +7197,7 @@
             "alternate_allele": "",
             "cdna_change": "",
             "protein_change": "",
-            "variant_annotation": "Oncogenic Mutations",
+            "variant_annotation": "",
             "exon": "",
             "rsid": "",
             "disease": "Ovarian Cancer",
@@ -7041,7 +7220,8 @@
             "nct": "",
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
-            "feature_display": "BRCA2 (Oncogenic Mutations)"
+            "_deprecated": false,
+            "feature_display": "BRCA2"
         },
         {
             "feature_type": "Somatic Variant",
@@ -7076,6 +7256,7 @@
             "nct": "",
             "publication_date": "2010-04-20",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -7111,6 +7292,7 @@
             "nct": "",
             "publication_date": "2017-02-21",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -7146,6 +7328,7 @@
             "nct": "NCT01682772",
             "publication_date": "2015-10-29",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -7181,6 +7364,7 @@
             "nct": "",
             "publication_date": "2015-02-25",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -7216,6 +7400,7 @@
             "nct": "",
             "publication_date": "2016-03-24",
             "last_updated": "2019-04-16",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Nonsense)"
         },
         {
@@ -7251,6 +7436,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -7286,6 +7472,7 @@
             "nct": "",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -7321,6 +7508,7 @@
             "nct": "",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -7356,6 +7544,7 @@
             "nct": "",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -7391,6 +7580,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRIP1"
         },
         {
@@ -7426,6 +7616,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRIP1"
         },
         {
@@ -7461,6 +7652,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRIP1"
         },
         {
@@ -7496,6 +7688,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRIP1"
         },
         {
@@ -7531,6 +7724,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRIP1"
         },
         {
@@ -7566,6 +7760,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRIP1"
         },
         {
@@ -7601,6 +7796,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "BRIP1"
         },
         {
@@ -7636,6 +7832,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "CDK12"
         },
         {
@@ -7671,6 +7868,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -7706,6 +7904,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -7741,6 +7940,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -7776,6 +7976,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -7811,6 +8012,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -7846,6 +8048,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -7881,6 +8084,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -7916,6 +8120,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -7951,6 +8156,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -7986,6 +8192,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -8021,6 +8228,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -8056,6 +8264,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -8091,6 +8300,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -8126,6 +8336,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -8161,6 +8372,7 @@
             "nct": "",
             "publication_date": "2010-09-07",
             "last_updated": "2019-09-12",
+            "_deprecated": false,
             "feature_display": "CTNNB1"
         },
         {
@@ -8189,13 +8401,14 @@
             "predictive_implication": "FDA-Approved",
             "description": "Osimertinib is a kinase inhibitor indicated for the treatment of patients with metastatic epidermal growth factor receptor (EGFR) T790M mutation positive non-small cell lung cancer (NSCLC), as detected by an FDA approved test, whose disease has progressed on or after EGFR TKI therapy.",
             "source_type": "FDA",
-            "citation": "AstraZeneca Pharmaceuticals, LP. Tagrisso (osimertinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/208065s016lbl.pdf. Revised May 2020. Accessed November 12, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/208065s016lbl.pdf",
+            "citation": "AstraZeneca Pharmaceuticals, LP. Tagrisso (osimertinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2017/208065s006lbl.pdf. Revised March 2017. Accessed March 4, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2017/208065s006lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-05-01",
-            "last_updated": "2020-11-12",
+            "publication_date": "2017-03-30",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8231,6 +8444,7 @@
             "nct": "",
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "EGFR"
         },
         {
@@ -8266,6 +8480,7 @@
             "nct": "",
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "EGFR"
         },
         {
@@ -8301,6 +8516,7 @@
             "nct": "",
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8336,6 +8552,7 @@
             "nct": "",
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "EGFR"
         },
         {
@@ -8371,6 +8588,7 @@
             "nct": "",
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "EGFR"
         },
         {
@@ -8406,6 +8624,7 @@
             "nct": "",
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "EGFR Exon 20 (Insertion)"
         },
         {
@@ -8441,6 +8660,7 @@
             "nct": "NCT02143466",
             "publication_date": "2016-04-15",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8476,6 +8696,7 @@
             "nct": "NCT01588145",
             "publication_date": "2016-04-15",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8511,6 +8732,7 @@
             "nct": "NCT01708954",
             "publication_date": "2016-10-04",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "EGFR"
         },
         {
@@ -8546,6 +8768,7 @@
             "nct": "NCT01708954",
             "publication_date": "2016-10-04",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "EGFR"
         },
         {
@@ -8581,6 +8804,7 @@
             "nct": "NCT01708954",
             "publication_date": "2016-10-04",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "EGFR"
         },
         {
@@ -8615,7 +8839,8 @@
             "pmid": 27717507,
             "nct": "NCT01708954",
             "publication_date": "2016-10-04",
-            "last_updated": "2019-06-13",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -8651,6 +8876,7 @@
             "nct": "NCT01708954",
             "publication_date": "2016-10-04",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "EGFR"
         },
         {
@@ -8686,6 +8912,7 @@
             "nct": "NCT01708954",
             "publication_date": "2016-10-04",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8721,6 +8948,7 @@
             "nct": "NCT01526928",
             "publication_date": "2015-04-30",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8756,6 +8984,7 @@
             "nct": "",
             "publication_date": "2005-10-01",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "EGFR"
         },
         {
@@ -8791,6 +9020,7 @@
             "nct": "",
             "publication_date": "2016-04-12",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8825,7 +9055,8 @@
             "pmid": 27071706,
             "nct": "",
             "publication_date": "2016-04-12",
-            "last_updated": "2019-06-13",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -8861,6 +9092,7 @@
             "nct": "",
             "publication_date": "2016-04-12",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8895,7 +9127,8 @@
             "pmid": 27071706,
             "nct": "",
             "publication_date": "2016-04-12",
-            "last_updated": "2019-06-13",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -8931,6 +9164,7 @@
             "nct": "",
             "publication_date": "2016-04-12",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8966,6 +9200,7 @@
             "nct": "",
             "publication_date": "2014-02-01",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -9001,6 +9236,7 @@
             "nct": "",
             "publication_date": "2014-02-01",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -9036,6 +9272,7 @@
             "nct": "",
             "publication_date": "2019-10-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "EGFR"
         },
         {
@@ -9071,6 +9308,7 @@
             "nct": "",
             "publication_date": "2019-10-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "EGFR (Nonsense)"
         },
         {
@@ -9105,7 +9343,8 @@
             "pmid": "",
             "nct": "",
             "publication_date": "2019-10-01",
-            "last_updated": "2020-11-12",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -9141,6 +9380,7 @@
             "nct": "",
             "publication_date": "2013-10-01",
             "last_updated": "2019-08-09",
+            "_deprecated": false,
             "feature_display": "EGFR"
         },
         {
@@ -9176,6 +9416,7 @@
             "nct": "",
             "publication_date": "2018-01-11",
             "last_updated": "2019-08-15",
+            "_deprecated": false,
             "feature_display": "EGFR Exon 19 (Nonsense)"
         },
         {
@@ -9189,8 +9430,8 @@
             "cdna_change": "c.2573T>G",
             "protein_change": "p.L858R",
             "variant_annotation": "Missense",
-            "exon": "",
-            "rsid": "",
+            "exon": 21,
+            "rsid": "rs121434568",
             "disease": "Non-Small Cell Lung Cancer",
             "context": "Advanced",
             "oncotree_term": "Non-Small Cell Lung Cancer",
@@ -9210,7 +9451,8 @@
             "pmid": 29151359,
             "nct": "",
             "publication_date": "2018-01-11",
-            "last_updated": "2019-08-15",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -9244,8 +9486,9 @@
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-12-01",
-            "last_updated": "2021-02-02",
+            "publication_date": "2020-12-11",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
             "feature_display": "EGFR Exon 19 (Deletion)"
         },
         {
@@ -9260,7 +9503,7 @@
             "protein_change": "p.L858R",
             "variant_annotation": "Missense",
             "exon": 21,
-            "rsid": "",
+            "rsid": "rs121434568",
             "disease": "Non-Small Cell Lung Cancer",
             "context": "",
             "oncotree_term": "Non-Small Cell Lung Cancer",
@@ -9279,8 +9522,9 @@
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-12-01",
-            "last_updated": "2021-02-02",
+            "publication_date": "2020-12-11",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -9300,7 +9544,7 @@
             "context": "Locally advanced or metastatic disease which has progressed on or after platinum-based chemotherapy.",
             "oncotree_term": "Non-Small Cell Lung Cancer",
             "oncotree_code": "NSCLC",
-            "therapy_name": "Amivantamab",
+            "therapy_name": "Amivantamab-vmjw",
             "therapy_strategy": "EGFR inhibition",
             "therapy_type": "Targeted therapy",
             "therapy_sensitivity": 1,
@@ -9314,8 +9558,9 @@
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2021-05-01",
-            "last_updated": "2021-06-01",
+            "publication_date": "2021-05-21",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
             "feature_display": "EGFR Exon 20 (Insertion)"
         },
         {
@@ -9351,6 +9596,7 @@
             "nct": "",
             "publication_date": "2021-09-01",
             "last_updated": "2021-09-16",
+            "_deprecated": false,
             "feature_display": "EGFR Exon 20 (Insertion)"
         },
         {
@@ -9386,6 +9632,7 @@
             "nct": "",
             "publication_date": "2018-01-31",
             "last_updated": "2018-09-10",
+            "_deprecated": false,
             "feature_display": "ERBB2 (Missense)"
         },
         {
@@ -9421,6 +9668,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ERBB2"
         },
         {
@@ -9456,6 +9704,7 @@
             "nct": "",
             "publication_date": "2018-01-31",
             "last_updated": "2018-09-10",
+            "_deprecated": false,
             "feature_display": "ERBB3 (Missense)"
         },
         {
@@ -9491,6 +9740,7 @@
             "nct": "",
             "publication_date": "2016-06-16",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "ERCC2 (Missense)"
         },
         {
@@ -9526,6 +9776,7 @@
             "nct": "",
             "publication_date": "2014-09-30",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "ERCC2 (Missense)"
         },
         {
@@ -9561,6 +9812,7 @@
             "nct": "",
             "publication_date": "2014-02-13",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "ERRFI1 p.E384* (Nonsense)"
         },
         {
@@ -9596,6 +9848,7 @@
             "nct": "",
             "publication_date": "2013-11-03",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "ESR1"
         },
         {
@@ -9631,6 +9884,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ETV6 (Nonsense)"
         },
         {
@@ -9666,6 +9920,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ETV6 (Frameshift)"
         },
         {
@@ -9701,6 +9956,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "EZH2 (Nonsense)"
         },
         {
@@ -9736,6 +9992,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "EZH2 (Frameshift)"
         },
         {
@@ -9771,6 +10028,7 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-10",
+            "_deprecated": false,
             "feature_display": "EZH2 p.Y646* (Nonsense)"
         },
         {
@@ -9806,6 +10064,7 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-10",
+            "_deprecated": false,
             "feature_display": "EZH2 p.Y646F (Missense)"
         },
         {
@@ -9841,6 +10100,7 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-10",
+            "_deprecated": false,
             "feature_display": "EZH2 p.Y646N (Missense)"
         },
         {
@@ -9876,6 +10136,7 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-10",
+            "_deprecated": false,
             "feature_display": "EZH2 p.A682G (Missense)"
         },
         {
@@ -9911,6 +10172,7 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-10",
+            "_deprecated": false,
             "feature_display": "EZH2 p.A692V (Missense)"
         },
         {
@@ -9946,6 +10208,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "FANCL"
         },
         {
@@ -9981,6 +10244,7 @@
             "nct": "",
             "publication_date": "2008-09-12",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "FBXW7 (Missense)"
         },
         {
@@ -10007,15 +10271,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "Erdafitinib is indictated for the treatment of adult patients with locally advanced or metastatic urothelial carcinoma that has susceptible FGFR3 or FGFR2 genetic alterations, and has progressed during or following at least one line of prior platinum-containing chemotherapy including within 12 months of neoadjuvant or adjuvant platinum-containing chemotherapy.",
+            "description": "The U.S. Food and Drug Administration (FDA) has granted approval to erdafitinib for the treatment of adult patients with locally advanced or metastatic urothelial carcinoma with susceptible FGFR3 genetic alterations, and has progressed during or following at least one line of systemic therapy, as determined by an FDA-approved companion diagnostic. Erdafitinib is not recommended for the treatment of patients who are eligible for and have not received prior PD-1 or PD-L1 inhibitor therapy.",
             "source_type": "FDA",
-            "citation": "Janssen Products, LP. Balversa (erdafitinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125427s108lbl.pdf. Revised April 2020. Accessed November 12, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125427s108lbl.pdf",
+            "citation": "Janssen Products, LP. Balversa (erdafitinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/212018s007s008s009lbl.pdf. Revised January 2024. Accessed January 25, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/212018s007s008s009lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-04-01",
-            "last_updated": "2020-11-12",
+            "publication_date": "2024-01-19",
+            "last_updated": "2024-01-25",
+            "_deprecated": false,
             "feature_display": "FGFR3 p.R248C (Missense)"
         },
         {
@@ -10042,15 +10307,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "Erdafitinib is indictated for the treatment of adult patients with locally advanced or metastatic urothelial carcinoma that has susceptible FGFR3 or FGFR2 genetic alterations, and has progressed during or following at least one line of prior platinum-containing chemotherapy including within 12 months of neoadjuvant or adjuvant platinum-containing chemotherapy.",
+            "description": "The U.S. Food and Drug Administration (FDA) has granted approval to erdafitinib for the treatment of adult patients with locally advanced or metastatic urothelial carcinoma with susceptible FGFR3 genetic alterations, and has progressed during or following at least one line of systemic therapy, as determined by an FDA-approved companion diagnostic. Erdafitinib is not recommended for the treatment of patients who are eligible for and have not received prior PD-1 or PD-L1 inhibitor therapy.",
             "source_type": "FDA",
-            "citation": "Janssen Products, LP. Balversa (erdafitinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125427s108lbl.pdf. Revised April 2020. Accessed November 12, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125427s108lbl.pdf",
+            "citation": "Janssen Products, LP. Balversa (erdafitinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/212018s007s008s009lbl.pdf. Revised January 2024. Accessed January 25, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/212018s007s008s009lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-04-01",
-            "last_updated": "2020-11-12",
+            "publication_date": "2024-01-19",
+            "last_updated": "2024-01-25",
+            "_deprecated": false,
             "feature_display": "FGFR3 p.S249C (Missense)"
         },
         {
@@ -10077,15 +10343,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "Erdafitinib is indictated for the treatment of adult patients with locally advanced or metastatic urothelial carcinoma that has susceptible FGFR3 or FGFR2 genetic alterations, and has progressed during or following at least one line of prior platinum-containing chemotherapy including within 12 months of neoadjuvant or adjuvant platinum-containing chemotherapy.",
+            "description": "The U.S. Food and Drug Administration (FDA) has granted approval to erdafitinib for the treatment of adult patients with locally advanced or metastatic urothelial carcinoma with susceptible FGFR3 genetic alterations, and has progressed during or following at least one line of systemic therapy, as determined by an FDA-approved companion diagnostic. Erdafitinib is not recommended for the treatment of patients who are eligible for and have not received prior PD-1 or PD-L1 inhibitor therapy.",
             "source_type": "FDA",
-            "citation": "Janssen Products, LP. Balversa (erdafitinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125427s108lbl.pdf. Revised April 2020. Accessed November 12, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125427s108lbl.pdf",
+            "citation": "Janssen Products, LP. Balversa (erdafitinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/212018s007s008s009lbl.pdf. Revised January 2024. Accessed January 25, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/212018s007s008s009lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-04-01",
-            "last_updated": "2020-11-12",
+            "publication_date": "2024-01-19",
+            "last_updated": "2024-01-25",
+            "_deprecated": false,
             "feature_display": "FGFR3 p.G370C (Missense)"
         },
         {
@@ -10112,15 +10379,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "Erdafitinib is indictated for the treatment of adult patients with locally advanced or metastatic urothelial carcinoma that has susceptible FGFR3 or FGFR2 genetic alterations, and has progressed during or following at least one line of prior platinum-containing chemotherapy including within 12 months of neoadjuvant or adjuvant platinum-containing chemotherapy.",
+            "description": "The U.S. Food and Drug Administration (FDA) has granted approval to erdafitinib for the treatment of adult patients with locally advanced or metastatic urothelial carcinoma with susceptible FGFR3 genetic alterations, and has progressed during or following at least one line of systemic therapy, as determined by an FDA-approved companion diagnostic. Erdafitinib is not recommended for the treatment of patients who are eligible for and have not received prior PD-1 or PD-L1 inhibitor therapy.",
             "source_type": "FDA",
-            "citation": "Janssen Products, LP. Balversa (erdafitinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125427s108lbl.pdf. Revised April 2020. Accessed November 12, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125427s108lbl.pdf",
+            "citation": "Janssen Products, LP. Balversa (erdafitinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/212018s007s008s009lbl.pdf. Revised January 2024. Accessed January 25, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/212018s007s008s009lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-04-01",
-            "last_updated": "2020-11-12",
+            "publication_date": "2024-01-19",
+            "last_updated": "2024-01-25",
+            "_deprecated": false,
             "feature_display": "FGFR3 p.Y373C (Missense)"
         },
         {
@@ -10156,6 +10424,7 @@
             "nct": "",
             "publication_date": "2012-08-23",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "FLCN (Nonsense)"
         },
         {
@@ -10191,6 +10460,7 @@
             "nct": "",
             "publication_date": "2012-08-23",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "FLCN (Nonsense)"
         },
         {
@@ -10226,6 +10496,7 @@
             "nct": "",
             "publication_date": "2014-10-09",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "FLCN (Nonsense)"
         },
         {
@@ -10261,6 +10532,7 @@
             "nct": "",
             "publication_date": "2014-10-09",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "FLCN (Frameshift)"
         },
         {
@@ -10296,6 +10568,7 @@
             "nct": "",
             "publication_date": "2014-10-09",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "FLCN (Frameshift)"
         },
         {
@@ -10331,6 +10604,7 @@
             "nct": "",
             "publication_date": "2014-10-09",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "FLCN (Frameshift)"
         },
         {
@@ -10366,6 +10640,7 @@
             "nct": "",
             "publication_date": "2013-01-16",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "FLT3 p.F691L (Missense)"
         },
         {
@@ -10401,6 +10676,7 @@
             "nct": "",
             "publication_date": "2006-09-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "FLT3 p.K663Q (Missense)"
         },
         {
@@ -10436,6 +10712,7 @@
             "nct": "",
             "publication_date": "2012-06-10",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "GATA3 p.M294K (Missense)"
         },
         {
@@ -10471,6 +10748,7 @@
             "nct": "NCT02074839",
             "publication_date": "2018-07-20",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "IDH1"
         },
         {
@@ -10506,6 +10784,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "IDH1"
         },
         {
@@ -10541,6 +10820,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "IDH1"
         },
         {
@@ -10576,6 +10856,7 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -10611,6 +10892,7 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -10646,6 +10928,7 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -10681,6 +10964,7 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -10716,6 +11000,7 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "IDH1"
         },
         {
@@ -10751,6 +11036,7 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "IDH1"
         },
         {
@@ -10786,6 +11072,7 @@
             "nct": "NCT01915498",
             "publication_date": "2019-09-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "IDH2 p.R140Q (Missense)"
         },
         {
@@ -10821,6 +11108,7 @@
             "nct": "NCT01915498",
             "publication_date": "2019-09-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "IDH2 p.R172S (Missense)"
         },
         {
@@ -10856,6 +11144,7 @@
             "nct": "NCT01915498",
             "publication_date": "2019-09-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "IDH2 p.R172K (Missense)"
         },
         {
@@ -10891,6 +11180,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "IDH2"
         },
         {
@@ -10926,6 +11216,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "IDH2"
         },
         {
@@ -10961,6 +11252,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "IDH2 p.R140Q (Missense)"
         },
         {
@@ -10996,6 +11288,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "IDH2 p.R172S (Missense)"
         },
         {
@@ -11031,6 +11324,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "IDH2 p.R172K (Missense)"
         },
         {
@@ -11066,6 +11360,7 @@
             "nct": "",
             "publication_date": "2017-02-28",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "JAK1"
         },
         {
@@ -11101,6 +11396,7 @@
             "nct": "",
             "publication_date": "2015-11-26",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "JAK1 p.V656F (Missense)"
         },
         {
@@ -11136,6 +11432,7 @@
             "nct": "",
             "publication_date": "2015-11-26",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "JAK1 p.A634D (Missense)"
         },
         {
@@ -11171,6 +11468,7 @@
             "nct": "",
             "publication_date": "2017-02-28",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "JAK2"
         },
         {
@@ -11206,6 +11504,7 @@
             "nct": "",
             "publication_date": "2005-04-28",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "JAK2 p.V617F (Missense)"
         },
         {
@@ -11241,6 +11540,7 @@
             "nct": "",
             "publication_date": "2014-11-13",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "JAK3 p.A572T (Missense)"
         },
         {
@@ -11276,6 +11576,7 @@
             "nct": "",
             "publication_date": "2014-11-13",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "JAK3 p.M511I (Missense)"
         },
         {
@@ -11311,6 +11612,7 @@
             "nct": "",
             "publication_date": "2014-11-13",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "JAK3 p.L857Q (Missense)"
         },
         {
@@ -11346,6 +11648,7 @@
             "nct": "",
             "publication_date": "2014-11-13",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "JAK3 p.A572T (Missense)"
         },
         {
@@ -11381,6 +11684,7 @@
             "nct": "",
             "publication_date": "2014-11-13",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "JAK3 p.M511I (Missense)"
         },
         {
@@ -11416,6 +11720,7 @@
             "nct": "",
             "publication_date": "2014-11-13",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "JAK3 p.L857Q (Missense)"
         },
         {
@@ -11432,7 +11737,7 @@
             "exon": "",
             "rsid": "",
             "disease": "Gastrointestinal Stromal Tumor",
-            "context": "Unresctable and/or metastatic",
+            "context": "Unresectable and/or metastatic",
             "oncotree_term": "Gastrointestinal Stromal Tumor",
             "oncotree_code": "GIST",
             "therapy_name": "Imatinib",
@@ -11451,6 +11756,7 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "KIT"
         },
         {
@@ -11463,7 +11769,7 @@
             "alternate_allele": "",
             "cdna_change": "",
             "protein_change": "",
-            "variant_annotation": "Oncogenic Mutations",
+            "variant_annotation": "",
             "exon": "",
             "rsid": "",
             "disease": "Gastrointestinal Stromal Tumor",
@@ -11486,7 +11792,8 @@
             "nct": "",
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
-            "feature_display": "KIT (Oncogenic Mutations)"
+            "_deprecated": false,
+            "feature_display": "KIT"
         },
         {
             "feature_type": "Somatic Variant",
@@ -11521,6 +11828,7 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "KIT"
         },
         {
@@ -11533,7 +11841,7 @@
             "alternate_allele": "",
             "cdna_change": "",
             "protein_change": "",
-            "variant_annotation": "Oncogenic Mutations",
+            "variant_annotation": "",
             "exon": "",
             "rsid": "",
             "disease": "Gastrointestinal Stromal Tumor",
@@ -11556,7 +11864,8 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
-            "feature_display": "KIT (Oncogenic Mutations)"
+            "_deprecated": false,
+            "feature_display": "KIT"
         },
         {
             "feature_type": "Somatic Variant",
@@ -11591,6 +11900,7 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "KIT p.T670I (Missense)"
         },
         {
@@ -11626,6 +11936,7 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "KIT p.V654A (Missense)"
         },
         {
@@ -11638,7 +11949,7 @@
             "alternate_allele": "",
             "cdna_change": "",
             "protein_change": "",
-            "variant_annotation": "Oncogenic Mutations",
+            "variant_annotation": "",
             "exon": "",
             "rsid": "",
             "disease": "Gastrointestinal Stromal Tumor",
@@ -11661,7 +11972,8 @@
             "nct": "",
             "publication_date": "2020-08-14",
             "last_updated": "2020-11-12",
-            "feature_display": "KIT (Oncogenic Mutations)"
+            "_deprecated": false,
+            "feature_display": "KIT"
         },
         {
             "feature_type": "Somatic Variant",
@@ -11696,6 +12008,7 @@
             "nct": "",
             "publication_date": "2020-08-14",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "KIT p.T670I (Missense)"
         },
         {
@@ -11731,6 +12044,7 @@
             "nct": "",
             "publication_date": "2020-08-14",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "KIT p.V654A (Missense)"
         },
         {
@@ -11766,6 +12080,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT"
         },
         {
@@ -11801,6 +12116,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT Exon 11"
         },
         {
@@ -11836,6 +12152,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT Exon 13"
         },
         {
@@ -11871,6 +12188,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT p.W557C (Missense)"
         },
         {
@@ -11906,6 +12224,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT p.W557G (Missense)"
         },
         {
@@ -11941,6 +12260,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT p.W557R (Missense)"
         },
         {
@@ -11976,6 +12296,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT p.V559A (Missense)"
         },
         {
@@ -12011,6 +12332,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT p.V559G (Missense)"
         },
         {
@@ -12046,6 +12368,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT p.L576P (Missense)"
         },
         {
@@ -12081,6 +12404,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT p.K642E (Missense)"
         },
         {
@@ -12116,6 +12440,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT Exon 17"
         },
         {
@@ -12151,6 +12476,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT p.D816H (Missense)"
         },
         {
@@ -12186,6 +12512,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT"
         },
         {
@@ -12221,6 +12548,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT Exon 11"
         },
         {
@@ -12256,6 +12584,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT Exon 9"
         },
         {
@@ -12291,6 +12620,7 @@
             "nct": "",
             "publication_date": "2020-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT"
         },
         {
@@ -12326,6 +12656,7 @@
             "nct": "",
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "KIT p.D816V (Missense)"
         },
         {
@@ -12361,6 +12692,7 @@
             "nct": "",
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "KIT Exon 17"
         },
         {
@@ -12396,6 +12728,7 @@
             "nct": "",
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "KIT"
         },
         {
@@ -12431,6 +12764,7 @@
             "nct": "",
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "KIT Exon 11"
         },
         {
@@ -12466,6 +12800,7 @@
             "nct": "NCT02154490",
             "publication_date": "2016-01-03",
             "last_updated": "2018-09-14",
+            "_deprecated": false,
             "feature_display": "KRAS"
         },
         {
@@ -12501,6 +12836,7 @@
             "nct": "NCT01155453",
             "publication_date": "2015-02-16",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "KRAS"
         },
         {
@@ -12536,6 +12872,7 @@
             "nct": "",
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KRAS Exon 2"
         },
         {
@@ -12571,6 +12908,7 @@
             "nct": "",
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KRAS Exon 2"
         },
         {
@@ -12606,6 +12944,7 @@
             "nct": "",
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KRAS Exon 3"
         },
         {
@@ -12641,6 +12980,7 @@
             "nct": "",
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KRAS Exon 3"
         },
         {
@@ -12676,6 +13016,7 @@
             "nct": "",
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KRAS Exon 4"
         },
         {
@@ -12711,6 +13052,7 @@
             "nct": "",
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KRAS Exon 4"
         },
         {
@@ -12721,7 +13063,7 @@
             "end_position": 25398285,
             "reference_allele": "C",
             "alternate_allele": "A",
-            "cdna_change": "c.35G>T",
+            "cdna_change": "c.34G>T",
             "protein_change": "p.G12C",
             "variant_annotation": "Missense",
             "exon": 2,
@@ -12745,7 +13087,8 @@
             "pmid": "",
             "nct": "",
             "publication_date": "2021-05-01",
-            "last_updated": "2021-06-01",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "KRAS p.G12C (Missense)"
         },
         {
@@ -12781,6 +13124,7 @@
             "nct": "",
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KRAS"
         },
         {
@@ -12816,6 +13160,7 @@
             "nct": "",
             "publication_date": "2016-03-24",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "KRAS p.G12D (Missense)"
         },
         {
@@ -12851,6 +13196,7 @@
             "nct": "",
             "publication_date": "2017-05-25",
             "last_updated": "2019-04-13",
+            "_deprecated": false,
             "feature_display": "KRAS p.G12 (Missense)"
         },
         {
@@ -12886,6 +13232,7 @@
             "nct": "",
             "publication_date": "2017-05-25",
             "last_updated": "2019-04-13",
+            "_deprecated": false,
             "feature_display": "KRAS p.G13 (Missense)"
         },
         {
@@ -12921,6 +13268,7 @@
             "nct": "",
             "publication_date": "2017-05-25",
             "last_updated": "2019-04-13",
+            "_deprecated": false,
             "feature_display": "KRAS p.Q61 (Missense)"
         },
         {
@@ -12956,6 +13304,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "KRAS"
         },
         {
@@ -12991,6 +13340,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "KRAS"
         },
         {
@@ -13026,6 +13376,7 @@
             "nct": "",
             "publication_date": "2015-03-12",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "KRAS"
         },
         {
@@ -13061,6 +13412,7 @@
             "nct": "",
             "publication_date": "2015-04-09",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "KRAS"
         },
         {
@@ -13096,6 +13448,7 @@
             "nct": "",
             "publication_date": "2014-04-03",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "KRAS"
         },
         {
@@ -13131,6 +13484,7 @@
             "nct": "",
             "publication_date": "2014-04-03",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "KRAS"
         },
         {
@@ -13166,6 +13520,7 @@
             "nct": "",
             "publication_date": "2019-09-13",
             "last_updated": "2019-08-08",
+            "_deprecated": false,
             "feature_display": "KRAS"
         },
         {
@@ -13201,6 +13556,7 @@
             "nct": "",
             "publication_date": "2015-05-11",
             "last_updated": "2019-08-08",
+            "_deprecated": false,
             "feature_display": "KRAS"
         },
         {
@@ -13236,6 +13592,7 @@
             "nct": "",
             "publication_date": "2009-12-1",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MAP2K1 p.P124L (Missense)"
         },
         {
@@ -13271,6 +13628,7 @@
             "nct": "",
             "publication_date": "2009-12-1",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MAP2K1 p.Q56P (Missense)"
         },
         {
@@ -13306,6 +13664,7 @@
             "nct": "",
             "publication_date": "2009-12-1",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MAP2K1 p.P124L (Missense)"
         },
         {
@@ -13341,6 +13700,7 @@
             "nct": "",
             "publication_date": "2015-07-15",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MAP2K1 p.Q56P (Missense)"
         },
         {
@@ -13376,6 +13736,7 @@
             "nct": "",
             "publication_date": "2013-04-08",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MAP2K1 p.Q56P (Missense)"
         },
         {
@@ -13411,6 +13772,7 @@
             "nct": "",
             "publication_date": "2013-04-08",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MAP2K1 p.Q56P (Missense)"
         },
         {
@@ -13446,6 +13808,7 @@
             "nct": "",
             "publication_date": "2011-03-07",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MAP2K1 p.C121S (Missense)"
         },
         {
@@ -13481,6 +13844,7 @@
             "nct": "",
             "publication_date": "2011-03-07",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MAP2K1 p.C121S (Missense)"
         },
         {
@@ -13516,6 +13880,7 @@
             "nct": "",
             "publication_date": "2014-01-07",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MAP2K2 p.Q60P (Missense)"
         },
         {
@@ -13551,6 +13916,7 @@
             "nct": "",
             "publication_date": "2015-03-05",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MAPK1 p.E322K (Missense)"
         },
         {
@@ -13586,6 +13952,7 @@
             "nct": "",
             "publication_date": "2016-08-19",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "MC1R"
         },
         {
@@ -13621,6 +13988,7 @@
             "nct": "",
             "publication_date": "2009-03-17",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MET p.T1010I (Missense)"
         },
         {
@@ -13656,6 +14024,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "MET Exon 14 (Splice Site)"
         },
         {
@@ -13691,42 +14060,8 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "MET Exon 14 (Deletion)"
-        },
-        {
-            "feature_type": "Somatic Variant",
-            "gene": "MET",
-            "chromosome": "7",
-            "start_position": "",
-            "end_position": "",
-            "reference_allele": "",
-            "alternate_allele": "",
-            "cdna_change": "",
-            "protein_change": "",
-            "variant_annotation": "Nonsense",
-            "exon": 14,
-            "rsid": "",
-            "disease": "Non-Small Cell Lung Cancer",
-            "context": "Metastatic",
-            "oncotree_term": "Non-Small Cell Lung Cancer",
-            "oncotree_code": "NSCLC",
-            "therapy_name": "Crizotinib",
-            "therapy_strategy": "MET inhibition",
-            "therapy_type": "Targeted therapy",
-            "therapy_sensitivity": 1,
-            "therapy_resistance": "",
-            "favorable_prognosis": "",
-            "predictive_implication": "Guideline",
-            "description": "Crizotinib (Xalkori) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with metastatic non-small cell lung cancer whose tumors harbor MET exon 14 skipping variants.",
-            "source_type": "Guideline",
-            "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.5.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
-            "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
-            "doi": "",
-            "pmid": "",
-            "nct": "",
-            "publication_date": "2019-01-01",
-            "last_updated": "2023-11-02",
-            "feature_display": "MET Exon 14 (Nonsense)"
         },
         {
             "feature_type": "Somatic Variant",
@@ -13752,15 +14087,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to capmatinib for adult patients with metastatic non-small cell lung cancer whose tumors have a mutation that leads to MET exon 14 skipping as detected by an FDA-approved test.",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to capmatinib for adult patients with metastatic non-small cell lung cancer whose tumors have a mutation that leads to MET exon 14 skipping as detected by an FDA-approved test.",
             "source_type": "FDA",
-            "citation": "Novartis Pharmaceuticals Corporation. Tabrecta (capmatinib) [package insert]. U.S. Food and Drug Administration website. www.accessdata.fda.gov/drugsatfda_docs/label/2020/213591s000lbl.pdf. Revised May 2020. Accessed October 15, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/213591s000lbl.pdf",
+            "citation": "Novartis Pharmaceuticals Corporation. Tabrecta (capmatinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2022/213591s004lbl.pdf. Revised August 2022. Accessed March 4, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2022/213591s004lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-05-01",
-            "last_updated": "2020-10-15",
+            "publication_date": "2022-08-10",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
             "feature_display": "MET Exon 14 (Splice Site)"
         },
         {
@@ -13787,51 +14123,17 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to capmatinib for adult patients with metastatic non-small cell lung cancer whose tumors have a mutation that leads to MET exon 14 skipping as detected by an FDA-approved test.",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to capmatinib for adult patients with metastatic non-small cell lung cancer whose tumors have a mutation that leads to MET exon 14 skipping as detected by an FDA-approved test.",
             "source_type": "FDA",
-            "citation": "Novartis Pharmaceuticals Corporation. Tabrecta (capmatinib) [package insert]. U.S. Food and Drug Administration website. www.accessdata.fda.gov/drugsatfda_docs/label/2020/213591s000lbl.pdf. Revised May 2020. Accessed October 15, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/213591s000lbl.pdf",
+            "citation": "Novartis Pharmaceuticals Corporation. Tabrecta (capmatinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2022/213591s004lbl.pdf. Revised August 2022. Accessed March 4, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2022/213591s004lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-05-01",
-            "last_updated": "2020-10-15",
+            "publication_date": "2022-08-10",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
             "feature_display": "MET Exon 14 (Deletion)"
-        },
-        {
-            "feature_type": "Somatic Variant",
-            "gene": "MET",
-            "chromosome": "7",
-            "start_position": "",
-            "end_position": "",
-            "reference_allele": "",
-            "alternate_allele": "",
-            "cdna_change": "",
-            "protein_change": "",
-            "variant_annotation": "Nonsense",
-            "exon": 14,
-            "rsid": "",
-            "disease": "Non-Small Cell Lung Cancer",
-            "context": "Metastatic",
-            "oncotree_term": "Non-Small Cell Lung Cancer",
-            "oncotree_code": "NSCLC",
-            "therapy_name": "Capmatinib",
-            "therapy_strategy": "MET inhibition",
-            "therapy_type": "Targeted therapy",
-            "therapy_sensitivity": 1,
-            "therapy_resistance": "",
-            "favorable_prognosis": "",
-            "predictive_implication": "FDA-Approved",
-            "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to capmatinib for adult patients with metastatic non-small cell lung cancer whose tumors have a mutation that leads to MET exon 14 skipping as detected by an FDA-approved test.",
-            "source_type": "FDA",
-            "citation": "Novartis Pharmaceuticals Corporation. Tabrecta (capmatinib) [package insert]. U.S. Food and Drug Administration website. www.accessdata.fda.gov/drugsatfda_docs/label/2020/213591s000lbl.pdf. Revised May 2020. Accessed October 15, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/213591s000lbl.pdf",
-            "doi": "",
-            "pmid": "",
-            "nct": "",
-            "publication_date": "2020-05-01",
-            "last_updated": "2020-10-15",
-            "feature_display": "MET Exon 14 (Nonsense)"
         },
         {
             "feature_type": "Somatic Variant",
@@ -13866,6 +14168,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "MLH3"
         },
         {
@@ -13901,6 +14204,7 @@
             "nct": "",
             "publication_date": "2011-10-18",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MPL p.W515L (Missense)"
         },
         {
@@ -13936,6 +14240,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "MSH2"
         },
         {
@@ -13971,6 +14276,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "MSH6"
         },
         {
@@ -14006,6 +14312,7 @@
             "nct": "NCT00903175",
             "publication_date": "2019-01-15",
             "last_updated": "2019-08-12",
+            "_deprecated": false,
             "feature_display": "MTOR"
         },
         {
@@ -14041,6 +14348,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "MYH"
         },
         {
@@ -14076,6 +14384,7 @@
             "nct": "",
             "publication_date": "2013-10-14",
             "last_updated": "2019-03-25",
+            "_deprecated": false,
             "feature_display": "NFE2L2 (Activating mutation)"
         },
         {
@@ -14111,6 +14420,7 @@
             "nct": "",
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS"
         },
         {
@@ -14146,6 +14456,7 @@
             "nct": "",
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS"
         },
         {
@@ -14181,6 +14492,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.G12A (Missense)"
         },
         {
@@ -14195,7 +14507,7 @@
             "protein_change": "p.G12C",
             "variant_annotation": "Missense",
             "exon": 2,
-            "rsid": "",
+            "rsid": "rs121913250",
             "disease": "Myelodysplastic Syndromes",
             "context": "",
             "oncotree_term": "Myelodysplasia",
@@ -14215,7 +14527,8 @@
             "pmid": "",
             "nct": "",
             "publication_date": "2023-10-17",
-            "last_updated": "2023-11-02",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "NRAS p.G12C (Missense)"
         },
         {
@@ -14251,6 +14564,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.G12D (Missense)"
         },
         {
@@ -14286,6 +14600,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.G12R (Missense)"
         },
         {
@@ -14321,6 +14636,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.G12S (Missense)"
         },
         {
@@ -14356,6 +14672,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.G12V (Missense)"
         },
         {
@@ -14391,6 +14708,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.G13A (Missense)"
         },
         {
@@ -14426,6 +14744,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.G13D (Missense)"
         },
         {
@@ -14461,6 +14780,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.G13R (Missense)"
         },
         {
@@ -14496,6 +14816,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.G13V (Missense)"
         },
         {
@@ -14531,6 +14852,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.Q61E (Missense)"
         },
         {
@@ -14566,6 +14888,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.Q61H (Missense)"
         },
         {
@@ -14601,6 +14924,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.Q61L (Missense)"
         },
         {
@@ -14636,6 +14960,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "NRAS p.Q61P (Missense)"
         },
         {
@@ -14671,6 +14996,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.Q61R (Missense)"
         },
         {
@@ -14685,7 +15011,7 @@
             "protein_change": "p.G12C",
             "variant_annotation": "Missense",
             "exon": 2,
-            "rsid": "",
+            "rsid": "rs121913250",
             "disease": "Melanoma",
             "context": "Metastatic",
             "oncotree_term": "Melanoma",
@@ -14705,7 +15031,8 @@
             "pmid": 18390968,
             "nct": "",
             "publication_date": "2016-09-21",
-            "last_updated": "2019-06-13",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "NRAS p.G12C (Missense)"
         },
         {
@@ -14741,6 +15068,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.G12D (Missense)"
         },
         {
@@ -14776,6 +15104,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.G12R (Missense)"
         },
         {
@@ -14811,6 +15140,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.G12S (Missense)"
         },
         {
@@ -14846,6 +15176,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.G12V (Missense)"
         },
         {
@@ -14881,6 +15212,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.G13A (Missense)"
         },
         {
@@ -14916,6 +15248,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.G13D (Missense)"
         },
         {
@@ -14951,6 +15284,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.G13R (Missense)"
         },
         {
@@ -14986,6 +15320,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.G13V (Missense)"
         },
         {
@@ -15021,6 +15356,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.Q61E (Missense)"
         },
         {
@@ -15056,6 +15392,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.Q61H (Missense)"
         },
         {
@@ -15091,6 +15428,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.Q61L (Missense)"
         },
         {
@@ -15126,6 +15464,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.Q61P (Missense)"
         },
         {
@@ -15161,6 +15500,7 @@
             "nct": "",
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS p.Q61R (Missense)"
         },
         {
@@ -15196,6 +15536,7 @@
             "nct": "",
             "publication_date": "2011-12-16",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "NRAS"
         },
         {
@@ -15231,6 +15572,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -15266,6 +15608,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -15301,6 +15644,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -15336,6 +15680,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -15371,6 +15716,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -15406,6 +15752,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -15441,6 +15788,7 @@
             "nct": "",
             "publication_date": "2015-02-25",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -15476,6 +15824,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -15511,6 +15860,7 @@
             "nct": "",
             "publication_date": "2018-01-04",
             "last_updated": "2018-09-11",
+            "_deprecated": false,
             "feature_display": "PBRM1 (Nonsense)"
         },
         {
@@ -15546,6 +15896,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "PDGFRA"
         },
         {
@@ -15581,6 +15932,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "PDGFRA p.D842V (Missense)"
         },
         {
@@ -15616,6 +15968,7 @@
             "nct": "",
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "PDGFRA p.D842V (Missense)"
         },
         {
@@ -15632,7 +15985,7 @@
             "exon": 18,
             "rsid": "",
             "disease": "Gastrointestinal Stromal Tumor",
-            "context": "Unresctable or metastatic",
+            "context": "Unresectable or metastatic",
             "oncotree_term": "Gastrointestinal Stromal Tumor",
             "oncotree_code": "GIST",
             "therapy_name": "Avapritinib",
@@ -15651,6 +16004,7 @@
             "nct": "",
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "PDGFRA Exon 18"
         },
         {
@@ -15667,7 +16021,7 @@
             "exon": 18,
             "rsid": "rs121908585",
             "disease": "Gastrointestinal Stromal Tumor",
-            "context": "Unresctable or metastatic",
+            "context": "Unresectable or metastatic",
             "oncotree_term": "Gastrointestinal Stromal Tumor",
             "oncotree_code": "GIST",
             "therapy_name": "Avapritinib",
@@ -15686,6 +16040,7 @@
             "nct": "",
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
+            "_deprecated": false,
             "feature_display": "PDGFRA p.D842V (Missense)"
         },
         {
@@ -15721,6 +16076,7 @@
             "nct": "",
             "publication_date": "2018-01-04",
             "last_updated": "2018-09-11",
+            "_deprecated": false,
             "feature_display": "PBRM1 (Frameshift)"
         },
         {
@@ -15756,6 +16112,7 @@
             "nct": "",
             "publication_date": "2020-09-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "PIK3CA"
         },
         {
@@ -15791,6 +16148,7 @@
             "nct": "",
             "publication_date": "2013-10-01",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA"
         },
         {
@@ -15826,6 +16184,7 @@
             "nct": "NCT01576172",
             "publication_date": "2017-12-20",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA"
         },
         {
@@ -15861,6 +16220,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.E545Q (Missense)"
         },
         {
@@ -15896,6 +16256,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.C420R (Missense)"
         },
         {
@@ -15931,6 +16292,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.E542K (Missense)"
         },
         {
@@ -15966,6 +16328,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.E542Q (Missense)"
         },
         {
@@ -16001,6 +16364,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.E545A (Missense)"
         },
         {
@@ -16036,6 +16400,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.E545D (Missense)"
         },
         {
@@ -16071,6 +16436,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.E545D (Missense)"
         },
         {
@@ -16106,6 +16472,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.E545G (Missense)"
         },
         {
@@ -16141,6 +16508,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.E545K (Missense)"
         },
         {
@@ -16176,6 +16544,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.G1049R (Missense)"
         },
         {
@@ -16211,6 +16580,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.G1049S (Missense)"
         },
         {
@@ -16246,6 +16616,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.H1047L (Missense)"
         },
         {
@@ -16281,6 +16652,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.H1047R (Missense)"
         },
         {
@@ -16316,6 +16688,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.H1047Y (Missense)"
         },
         {
@@ -16351,6 +16724,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.H701P (Missense)"
         },
         {
@@ -16386,6 +16760,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.M1043I (Missense)"
         },
         {
@@ -16421,6 +16796,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.M1043I (Missense)"
         },
         {
@@ -16456,6 +16832,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.P539R (Missense)"
         },
         {
@@ -16491,6 +16868,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.Q546K (Missense)"
         },
         {
@@ -16526,6 +16904,7 @@
             "nct": "",
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "PIK3CA p.Y1021C (Missense)"
         },
         {
@@ -16561,6 +16940,7 @@
             "nct": "",
             "publication_date": "2015-07-02",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "POLD1 p.D316H (Missense)"
         },
         {
@@ -16596,6 +16976,7 @@
             "nct": "",
             "publication_date": "2015-07-02",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "POLD1 p.D316G (Missense)"
         },
         {
@@ -16631,6 +17012,7 @@
             "nct": "",
             "publication_date": "2015-07-02",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "POLD1 p.R409W (Missense)"
         },
         {
@@ -16666,6 +17048,7 @@
             "nct": "",
             "publication_date": "2015-07-02",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "POLD1 p.L474P (Missense)"
         },
         {
@@ -16701,6 +17084,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "POLD1"
         },
         {
@@ -16736,6 +17120,7 @@
             "nct": "",
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "POLD1"
         },
         {
@@ -16771,6 +17156,7 @@
             "nct": "",
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "POLD1"
         },
         {
@@ -16806,6 +17192,7 @@
             "nct": "",
             "publication_date": "2015-07-02",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "POLE p.L424V (Missense)"
         },
         {
@@ -16841,6 +17228,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "POLE"
         },
         {
@@ -16876,6 +17264,7 @@
             "nct": "",
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "POLE"
         },
         {
@@ -16911,6 +17300,7 @@
             "nct": "",
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "POLE"
         },
         {
@@ -16946,6 +17336,7 @@
             "nct": "",
             "publication_date": "2014-12-16",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "PTEN (Nonsense)"
         },
         {
@@ -16981,6 +17372,7 @@
             "nct": "",
             "publication_date": "2014-12-16",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "PTEN (Frameshift)"
         },
         {
@@ -17016,6 +17408,7 @@
             "nct": "",
             "publication_date": "2014-12-16",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "PTEN (Splice Site)"
         },
         {
@@ -17051,6 +17444,7 @@
             "nct": "",
             "publication_date": "2017-02-21",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "PTEN (Nonsense)"
         },
         {
@@ -17086,6 +17480,7 @@
             "nct": "",
             "publication_date": "2017-02-21",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "PTEN (Frameshift)"
         },
         {
@@ -17121,6 +17516,7 @@
             "nct": "",
             "publication_date": "2017-02-21",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "PTEN (Splice Site)"
         },
         {
@@ -17156,6 +17552,7 @@
             "nct": "NCT01576172",
             "publication_date": "2017-12-20",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "PTEN"
         },
         {
@@ -17191,6 +17588,7 @@
             "nct": "",
             "publication_date": "2016-02-04",
             "last_updated": "2018-09-14",
+            "_deprecated": false,
             "feature_display": "PTEN (Nonsense)"
         },
         {
@@ -17226,6 +17624,7 @@
             "nct": "",
             "publication_date": "2016-02-04",
             "last_updated": "2018-09-14",
+            "_deprecated": false,
             "feature_display": "PTEN (Frameshift)"
         },
         {
@@ -17261,6 +17660,7 @@
             "nct": "",
             "publication_date": "2016-02-04",
             "last_updated": "2018-09-14",
+            "_deprecated": false,
             "feature_display": "PTEN (Splice Site)"
         },
         {
@@ -17296,6 +17696,7 @@
             "nct": "",
             "publication_date": "2016-02-04",
             "last_updated": "2018-09-14",
+            "_deprecated": false,
             "feature_display": "PTEN (Nonsense)"
         },
         {
@@ -17331,6 +17732,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "PTPN11"
         },
         {
@@ -17366,6 +17768,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "RAD51B"
         },
         {
@@ -17401,6 +17804,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -17436,6 +17840,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -17471,6 +17876,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -17506,6 +17912,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -17541,6 +17948,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -17576,6 +17984,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -17611,6 +18020,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -17646,6 +18056,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -17681,6 +18092,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -17716,6 +18128,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -17751,6 +18164,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -17786,6 +18200,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -17821,6 +18236,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -17856,6 +18272,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -17891,6 +18308,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "RAD54L"
         },
         {
@@ -17926,6 +18344,7 @@
             "nct": "",
             "publication_date": "2015-04-09",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RBM10"
         },
         {
@@ -17961,6 +18380,7 @@
             "nct": "",
             "publication_date": "2018-08-01",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "RET p.V804M (Missense)"
         },
         {
@@ -17996,6 +18416,7 @@
             "nct": "",
             "publication_date": "2018-08-01",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "RET p.M918T (Missense)"
         },
         {
@@ -18031,6 +18452,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "RET"
         },
         {
@@ -18066,6 +18488,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "RUNX1 (Nonsense)"
         },
         {
@@ -18101,6 +18524,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "RUNX1 (Frameshift)"
         },
         {
@@ -18136,6 +18560,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SETBP1 p.E858K (Missense)"
         },
         {
@@ -18171,6 +18596,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SETBP1 p.T864M (Missense)"
         },
         {
@@ -18206,6 +18632,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SETBP1 p.I865N (Missense)"
         },
         {
@@ -18241,6 +18668,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SETBP1 p.D868N (Missense)"
         },
         {
@@ -18276,6 +18704,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SETBP1 p.D868Y (Missense)"
         },
         {
@@ -18311,6 +18740,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SETBP1 p.S869C (Missense)"
         },
         {
@@ -18346,6 +18776,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SETBP1 p.G870S (Missense)"
         },
         {
@@ -18381,6 +18812,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.E622Q (Missense)"
         },
         {
@@ -18416,6 +18848,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.E622D (Missense)"
         },
         {
@@ -18451,6 +18884,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.Y623C (Missense)"
         },
         {
@@ -18486,6 +18920,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.R625C (Missense)"
         },
         {
@@ -18521,6 +18956,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.R625H (Missense)"
         },
         {
@@ -18556,6 +18992,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.N626H (Missense)"
         },
         {
@@ -18591,6 +19028,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.N626Y (Missense)"
         },
         {
@@ -18626,6 +19064,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.N626D (Missense)"
         },
         {
@@ -18661,6 +19100,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.H662R (Missense)"
         },
         {
@@ -18696,6 +19136,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.T663P (Missense)"
         },
         {
@@ -18731,6 +19172,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.K666N (Missense)"
         },
         {
@@ -18766,6 +19208,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.K666T (Missense)"
         },
         {
@@ -18801,6 +19244,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.K666E (Missense)"
         },
         {
@@ -18836,6 +19280,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.K700E (Missense)"
         },
         {
@@ -18871,6 +19316,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.I704S (Missense)"
         },
         {
@@ -18906,6 +19352,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.G740E (Missense)"
         },
         {
@@ -18941,6 +19388,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.G740V (Missense)"
         },
         {
@@ -18976,6 +19424,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.G742D (Missense)"
         },
         {
@@ -19011,6 +19460,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "SF3B1 p.D781E (Missense)"
         },
         {
@@ -19046,6 +19496,7 @@
             "nct": "",
             "publication_date": "2017-01-19",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "SMARCA4 (Nonsense)"
         },
         {
@@ -19081,6 +19532,7 @@
             "nct": "",
             "publication_date": "2017-01-19",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "SMARCA4 (Frameshift)"
         },
         {
@@ -19116,6 +19568,7 @@
             "nct": "",
             "publication_date": "2017-01-19",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "SMARCA4 (Splice Site)"
         },
         {
@@ -19151,6 +19604,7 @@
             "nct": "",
             "publication_date": "2020-11-01",
             "last_updated": "2022-10-06",
+            "_deprecated": false,
             "feature_display": "SPOP (Missense)"
         },
         {
@@ -19186,6 +19640,7 @@
             "nct": "",
             "publication_date": "2018-11-15",
             "last_updated": "2021-11-03",
+            "_deprecated": false,
             "feature_display": "SPOP (Missense)"
         },
         {
@@ -19221,6 +19676,7 @@
             "nct": "",
             "publication_date": "2021-09-07",
             "last_updated": "2021-11-03",
+            "_deprecated": false,
             "feature_display": "SPOP (Missense)"
         },
         {
@@ -19256,6 +19712,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "STAG2 (Nonsense)"
         },
         {
@@ -19291,6 +19748,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "STAG2 (Frameshift)"
         },
         {
@@ -19326,6 +19784,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "STAG2 (Splice Site)"
         },
         {
@@ -19361,6 +19820,7 @@
             "nct": "",
             "publication_date": "2011-04-15",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "TET2"
         },
         {
@@ -19396,6 +19856,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "TP53 (Missense)"
         },
         {
@@ -19431,6 +19892,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "TP53 (Nonsense)"
         },
         {
@@ -19466,6 +19928,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "TP53 (Frameshift)"
         },
         {
@@ -19501,6 +19964,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "TP53 (Splice Site)"
         },
         {
@@ -19536,6 +20000,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "TP53 (Nonsense)"
         },
         {
@@ -19571,6 +20036,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "TP53 (Frameshift)"
         },
         {
@@ -19606,6 +20072,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "TP53 (Splice Site)"
         },
         {
@@ -19641,6 +20108,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "TP53 (Missense)"
         },
         {
@@ -19676,6 +20144,7 @@
             "nct": "",
             "publication_date": "2010-12-07",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "TP53"
         },
         {
@@ -19711,6 +20180,7 @@
             "nct": "NCT01576172",
             "publication_date": "2017-12-20",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "TP53"
         },
         {
@@ -19746,6 +20216,7 @@
             "nct": "",
             "publication_date": "2019-09-13",
             "last_updated": "2019-08-08",
+            "_deprecated": false,
             "feature_display": "TP53"
         },
         {
@@ -19781,6 +20252,7 @@
             "nct": "",
             "publication_date": "2020-02-01",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "TSC1"
         },
         {
@@ -19816,6 +20288,7 @@
             "nct": "",
             "publication_date": "2012-08-23",
             "last_updated": "2018-09-19",
+            "_deprecated": false,
             "feature_display": "TSC1 (Nonsense)"
         },
         {
@@ -19851,6 +20324,7 @@
             "nct": "",
             "publication_date": "2012-08-23",
             "last_updated": "2018-09-19",
+            "_deprecated": false,
             "feature_display": "TSC1 (Frameshift)"
         },
         {
@@ -19886,6 +20360,7 @@
             "nct": "",
             "publication_date": "2014-10-09",
             "last_updated": "2018-09-19",
+            "_deprecated": false,
             "feature_display": "TSC1 (Nonsense)"
         },
         {
@@ -19921,6 +20396,7 @@
             "nct": "",
             "publication_date": "2014-10-09",
             "last_updated": "2018-09-19",
+            "_deprecated": false,
             "feature_display": "TSC1 (Frameshift)"
         },
         {
@@ -19956,6 +20432,7 @@
             "nct": "NCT00903175",
             "publication_date": "2019-01-15",
             "last_updated": "2019-08-12",
+            "_deprecated": false,
             "feature_display": "TSC1"
         },
         {
@@ -19991,6 +20468,7 @@
             "nct": "NCT00903175",
             "publication_date": "2019-01-15",
             "last_updated": "2019-08-12",
+            "_deprecated": false,
             "feature_display": "TSC2"
         },
         {
@@ -20003,7 +20481,7 @@
             "alternate_allele": "",
             "cdna_change": "",
             "protein_change": "",
-            "variant_annotation": "Oncogenic Mutations",
+            "variant_annotation": "",
             "exon": "",
             "rsid": "",
             "disease": "Subependymal giant cell astrocytoma",
@@ -20026,7 +20504,8 @@
             "nct": "",
             "publication_date": "2020-02-01",
             "last_updated": "2023-10-05",
-            "feature_display": "TSC2 (Oncogenic Mutations)"
+            "_deprecated": false,
+            "feature_display": "TSC2"
         },
         {
             "feature_type": "Somatic Variant",
@@ -20061,6 +20540,7 @@
             "nct": "",
             "publication_date": "2012-08-23",
             "last_updated": "2018-09-19",
+            "_deprecated": false,
             "feature_display": "TSC2 (Nonsense)"
         },
         {
@@ -20096,6 +20576,7 @@
             "nct": "",
             "publication_date": "2012-08-23",
             "last_updated": "2018-09-19",
+            "_deprecated": false,
             "feature_display": "TSC2 (Frameshift)"
         },
         {
@@ -20131,6 +20612,7 @@
             "nct": "",
             "publication_date": "2014-10-09",
             "last_updated": "2018-09-19",
+            "_deprecated": false,
             "feature_display": "TSC2 (Nonsense)"
         },
         {
@@ -20166,6 +20648,7 @@
             "nct": "",
             "publication_date": "2014-10-09",
             "last_updated": "2018-09-19",
+            "_deprecated": false,
             "feature_display": "TSC2 (Frameshift)"
         },
         {
@@ -20201,6 +20684,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "ZRSR2 (Nonsense)"
         },
         {
@@ -20236,6 +20720,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "ZRSR2 (Frameshift)"
         },
         {
@@ -20273,6 +20758,7 @@
             "nct": "",
             "publication_date": "2009-08-01",
             "last_updated": "2019-09-12",
+            "_deprecated": false,
             "feature_display": "ATM"
         },
         {
@@ -20310,6 +20796,7 @@
             "nct": "",
             "publication_date": "2018-02-22",
             "last_updated": "2019-04-16",
+            "_deprecated": false,
             "feature_display": "ATM (Pathogenic)"
         },
         {
@@ -20347,6 +20834,7 @@
             "nct": "",
             "publication_date": "2017-04-01",
             "last_updated": "2019-08-15",
+            "_deprecated": false,
             "feature_display": "ATM (Pathogenic)"
         },
         {
@@ -20384,6 +20872,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -20421,6 +20910,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -20458,6 +20948,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -20495,6 +20986,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -20532,6 +21024,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -20569,6 +21062,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BARD1"
         },
         {
@@ -20606,6 +21100,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -20643,6 +21138,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -20680,6 +21176,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -20717,6 +21214,7 @@
             "nct": "",
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -20754,6 +21252,7 @@
             "nct": "NCT01844986",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -20791,6 +21290,7 @@
             "nct": "NCT01844986",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -20828,6 +21328,7 @@
             "nct": "NCT01844986",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -20865,6 +21366,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -20902,6 +21404,7 @@
             "nct": "",
             "publication_date": "2015-02-25",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -20939,6 +21442,7 @@
             "nct": "",
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -20976,6 +21480,7 @@
             "nct": "",
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21013,6 +21518,7 @@
             "nct": "",
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21050,6 +21556,7 @@
             "nct": "",
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21087,6 +21594,7 @@
             "nct": "NCT01945775",
             "publication_date": "2020-10-01",
             "last_updated": "2021-09-16",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21124,6 +21632,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21161,6 +21670,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21198,6 +21708,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21235,6 +21746,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21272,6 +21784,7 @@
             "nct": "",
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21309,6 +21822,7 @@
             "nct": "",
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21346,6 +21860,7 @@
             "nct": "",
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21383,6 +21898,7 @@
             "nct": "",
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21420,6 +21936,7 @@
             "nct": "NCT01945775",
             "publication_date": "2020-10-01",
             "last_updated": "2021-09-16",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21457,6 +21974,7 @@
             "nct": "",
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21494,6 +22012,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21531,6 +22050,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21568,6 +22088,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21605,6 +22126,7 @@
             "nct": "NCT01844986",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21642,6 +22164,7 @@
             "nct": "NCT01844986",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21679,6 +22202,7 @@
             "nct": "NCT01844986",
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21716,6 +22240,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -21753,6 +22278,7 @@
             "nct": "NCT01682772",
             "publication_date": "2015-10-29",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -21790,6 +22316,7 @@
             "nct": "",
             "publication_date": "2015-02-25",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -21827,6 +22354,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21864,6 +22392,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -21901,6 +22430,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -21938,6 +22468,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -21975,6 +22506,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -22012,6 +22544,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -22049,6 +22582,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK1"
         },
         {
@@ -22086,6 +22620,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -22123,6 +22658,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -22160,6 +22696,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -22197,6 +22734,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -22234,6 +22772,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -22271,6 +22810,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -22308,6 +22848,7 @@
             "nct": "",
             "publication_date": "2019-01-24",
             "last_updated": "2019-04-16",
+            "_deprecated": false,
             "feature_display": "CHEK2 (Pathogenic)"
         },
         {
@@ -22345,6 +22886,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "EPCAM"
         },
         {
@@ -22382,6 +22924,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "IL12RB1 p.Q32* (Nonsense)"
         },
         {
@@ -22419,6 +22962,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "IL12RB1 p.Q542* (Nonsense)"
         },
         {
@@ -22456,6 +23000,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "LIMK2 p.G574Rfs*12 (Frameshift)"
         },
         {
@@ -22493,6 +23038,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "LIMK2 p.C582Lfs*4 (Frameshift)"
         },
         {
@@ -22530,6 +23076,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "LIMK2 p.G684Tfs*16 (Frameshift)"
         },
         {
@@ -22567,6 +23114,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "MLH1"
         },
         {
@@ -22604,6 +23152,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "MLH3"
         },
         {
@@ -22641,6 +23190,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MRE11 p.R576* (Nonsense)"
         },
         {
@@ -22678,6 +23228,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MRE11 p.H356Tfs*34 (Frameshift)"
         },
         {
@@ -22715,6 +23266,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "MRE11 p.L7fs*18 (Frameshift)"
         },
         {
@@ -22752,6 +23304,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "MSH2"
         },
         {
@@ -22789,6 +23342,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "MSH2"
         },
         {
@@ -22826,6 +23380,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "MSH6"
         },
         {
@@ -22863,6 +23418,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "MSH6"
         },
         {
@@ -22900,6 +23456,7 @@
             "nct": "",
             "publication_date": "2008-12-16",
             "last_updated": "2019-09-12",
+            "_deprecated": false,
             "feature_display": "NF1"
         },
         {
@@ -22937,6 +23494,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -22974,6 +23532,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -23011,6 +23570,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -23048,6 +23608,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -23085,6 +23646,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -23122,6 +23684,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -23159,6 +23722,7 @@
             "nct": "",
             "publication_date": "2015-02-25",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -23196,6 +23760,7 @@
             "nct": "",
             "publication_date": "2018-02-22",
             "last_updated": "2019-04-16",
+            "_deprecated": false,
             "feature_display": "PALB2 (Pathogenic)"
         },
         {
@@ -23233,6 +23798,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "PMS2"
         },
         {
@@ -23270,6 +23836,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "POLE2 p.L469Ffs*17 (Frameshift)"
         },
         {
@@ -23307,6 +23874,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "POT1 p.D617Efs*9 (Frameshift)"
         },
         {
@@ -23344,6 +23912,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "POT1 p.R363* (Nonsense)"
         },
         {
@@ -23381,6 +23950,7 @@
             "nct": "",
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "POT1 p.N75Kfs*16 (Frameshift)"
         },
         {
@@ -23418,6 +23988,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -23455,6 +24026,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -23492,6 +24064,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -23529,6 +24102,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -23566,6 +24140,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -23603,6 +24178,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -23640,6 +24216,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -23677,6 +24254,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -23714,6 +24292,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -23751,6 +24330,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -23788,6 +24368,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -23825,6 +24406,7 @@
             "nct": "",
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD51D"
         },
         {
@@ -23862,6 +24444,7 @@
             "nct": "",
             "publication_date": "2009-12-16",
             "last_updated": "2019-09-12",
+            "_deprecated": false,
             "feature_display": "RB1"
         },
         {
@@ -23899,6 +24482,7 @@
             "nct": "",
             "publication_date": "2008-12-16",
             "last_updated": "2019-09-12",
+            "_deprecated": false,
             "feature_display": "TP53"
         },
         {
@@ -23926,6 +24510,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "AR Amplification"
         },
         {
@@ -23953,6 +24538,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "AR Amplification"
         },
         {
@@ -23980,6 +24566,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "AR Amplification"
         },
         {
@@ -24007,6 +24594,7 @@
             "nct": "",
             "publication_date": "2017-08-18",
             "last_updated": "2019-08-09",
+            "_deprecated": false,
             "feature_display": "AR Amplification"
         },
         {
@@ -24034,6 +24622,7 @@
             "nct": "",
             "publication_date": "2018-05-07",
             "last_updated": "2019-02-04",
+            "_deprecated": false,
             "feature_display": "ARID1A Deletion"
         },
         {
@@ -24061,6 +24650,7 @@
             "nct": "",
             "publication_date": "2011-11-16",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "AURKA Amplification"
         },
         {
@@ -24088,6 +24678,7 @@
             "nct": "",
             "publication_date": "2011-12-29",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "AURKA Amplification"
         },
         {
@@ -24115,6 +24706,7 @@
             "nct": "",
             "publication_date": "2016-10-02",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "AURKB Amplification"
         },
         {
@@ -24142,6 +24734,7 @@
             "nct": "",
             "publication_date": "2010-11-23",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRAF Amplification"
         },
         {
@@ -24169,6 +24762,7 @@
             "nct": "",
             "publication_date": "2014-01-07",
             "last_updated": "2019-06-13",
+            "_deprecated": false,
             "feature_display": "BRAF Amplification"
         },
         {
@@ -24196,6 +24790,7 @@
             "nct": "NCT01682772",
             "publication_date": "2015-10-29",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "BRCA2 Deletion"
         },
         {
@@ -24223,6 +24818,7 @@
             "nct": "",
             "publication_date": "2007-05-07",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CCND1 Amplification"
         },
         {
@@ -24250,6 +24846,7 @@
             "nct": "",
             "publication_date": "2015-04-09",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CCND1 Amplification"
         },
         {
@@ -24277,6 +24874,7 @@
             "nct": "",
             "publication_date": "2013-11-11",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CCNE1 Amplification"
         },
         {
@@ -24304,6 +24902,7 @@
             "nct": "NCT01295827",
             "publication_date": "2015-05-21",
             "last_updated": "2019-11-04",
+            "_deprecated": false,
             "feature_display": "CD274 Amplification"
         },
         {
@@ -24331,6 +24930,7 @@
             "nct": "",
             "publication_date": "2020-09-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "CD274 Amplification"
         },
         {
@@ -24358,6 +24958,7 @@
             "nct": "",
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-19",
+            "_deprecated": false,
             "feature_display": "CD274 Amplification"
         },
         {
@@ -24385,6 +24986,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2021-05-06",
+            "_deprecated": false,
             "feature_display": "CD274 Amplification"
         },
         {
@@ -24412,6 +25014,7 @@
             "nct": "",
             "publication_date": "2020-05-01",
             "last_updated": "2021-05-06",
+            "_deprecated": false,
             "feature_display": "CD274 Amplification"
         },
         {
@@ -24439,6 +25042,7 @@
             "nct": "",
             "publication_date": "2021-10-01",
             "last_updated": "2021-11-03",
+            "_deprecated": false,
             "feature_display": "CD274 Amplification"
         },
         {
@@ -24466,6 +25070,7 @@
             "nct": "",
             "publication_date": "2021-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "CDK4 Amplification"
         },
         {
@@ -24493,6 +25098,7 @@
             "nct": "",
             "publication_date": "2021-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "CDK4 Amplification"
         },
         {
@@ -24520,6 +25126,7 @@
             "nct": "NCT01209598",
             "publication_date": "2013-04-08",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "CDK4 Amplification"
         },
         {
@@ -24547,6 +25154,7 @@
             "nct": "",
             "publication_date": "2015-04-09",
             "last_updated": "2018-09-14",
+            "_deprecated": false,
             "feature_display": "CDK4 Amplification"
         },
         {
@@ -24574,6 +25182,7 @@
             "nct": "",
             "publication_date": "2016-02-11",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "CDKN2A Deletion"
         },
         {
@@ -24601,6 +25210,7 @@
             "nct": "",
             "publication_date": "2015-04-09",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CDKN2A Deletion"
         },
         {
@@ -24628,6 +25238,7 @@
             "nct": "",
             "publication_date": "2008-09-30",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CDKN2C Deletion"
         },
         {
@@ -24655,6 +25266,7 @@
             "nct": "",
             "publication_date": "2016-08-17",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CDKN2C Deletion"
         },
         {
@@ -24682,6 +25294,7 @@
             "nct": "",
             "publication_date": "2011-12-13",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CRKL Amplification"
         },
         {
@@ -24709,6 +25322,7 @@
             "nct": "",
             "publication_date": "2005-10-01",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "EGFR Amplification"
         },
         {
@@ -24736,6 +25350,7 @@
             "nct": "NCT00320385",
             "publication_date": "2010-02-01",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -24763,6 +25378,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -24790,6 +25406,7 @@
             "nct": "",
             "publication_date": "2018-12-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -24817,6 +25434,7 @@
             "nct": "",
             "publication_date": "2018-12-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -24835,15 +25453,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "Neratinib is indicated for extended adjuvant treatment of adult patients with early stage HER2-overexpressed/amplified breast cancer, following adjuvant trastuzumab-based therapy",
+            "description": "The U.S. Food and Drug Administration (FDA) approved neratinib as a single agent for the extended adjuvant treatment of adult patients with early stage HER2-positive breast cancer, following adjuvant trastuzumab-based therapy.",
             "source_type": "FDA",
-            "citation": "Pfizer, Inc. Lorbrena (lorlatinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/210868s001lbl.pdf. Revised May 2020. Accessed November 12, 2020.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/210868s001lbl.pdf",
+            "citation": "Puma Biotechnology, Inc. Nerlynx (neratinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/208051s009lbl.pdf. Revised June 2021. Accessed January 11, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/208051s009lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-05-01",
-            "last_updated": "2020-11-12",
+            "publication_date": "2017-07-17",
+            "last_updated": "2024-01-11",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -24871,6 +25490,7 @@
             "nct": "",
             "publication_date": "2020-01-01",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -24898,6 +25518,7 @@
             "nct": "",
             "publication_date": "2018-11-01",
             "last_updated": "2021-05-06",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -24925,6 +25546,7 @@
             "nct": "",
             "publication_date": "2018-11-01",
             "last_updated": "2021-05-06",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -24952,6 +25574,7 @@
             "nct": "",
             "publication_date": "2018-11-01",
             "last_updated": "2021-05-06",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -24979,6 +25602,7 @@
             "nct": "NCT01041404",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25006,6 +25630,7 @@
             "nct": "",
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25033,6 +25658,7 @@
             "nct": "",
             "publication_date": "1999-01-06",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25060,6 +25686,7 @@
             "nct": "",
             "publication_date": "2003-11-14",
             "last_updated": "2019-08-09",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25087,6 +25714,7 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25114,6 +25742,7 @@
             "nct": "",
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25141,6 +25770,7 @@
             "nct": "",
             "publication_date": "2020-12-01",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25159,15 +25789,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to pembrolizumab in combination with trastuzumab, fluoropyrimidine- and platinum- containing chemotherapy for the first-line treatments of patients with locally advanced unresectable or metastatic HER2-positive gastric adenocarcinoma.",
+            "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to pembrolizumab in combination with trastuzumab, fluoropyrimidine- and platinum- containing chemotherapy for the first-line treatments of patients with locally advanced unresectable or metastatic HER2-positive gastric adenocarcinoma. In November 2023, the FDA updated this indication to restrict use to patients whose tumors express PD-L1 (CPS ≥ 1), as determined by an FDA-approved test.",
             "source_type": "FDA",
-            "citation": "Merck Sharp & Dohme Corp. Keytruda (pembrolizumab) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/125514s097lbl.pdf. Revised May 2021. Accessed May 6, 2021.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/125514s097lbl.pdf",
+            "citation": "Merck Sharp & Dohme Corp. Keytruda (pembrolizumab) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/125514s148lbl.pdf. Revised November 2023. Accessed December 5, 2023.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/125514s148lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-05-01",
-            "last_updated": "2021-05-06",
+            "publication_date": "2023-11-08",
+            "last_updated": "2023-12-05",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25186,15 +25817,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to pembrolizumab in combination with trastuzumab, fluoropyrimidine- and platinum- containing chemotherapy for the first-line treatments of patients with locally advanced unresectable or metastatic HER2-positive gastroesophageal junction adenocarcinoma.",
+            "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to pembrolizumab in combination with trastuzumab, fluoropyrimidine- and platinum- containing chemotherapy for the first-line treatments of patients with locally advanced unresectable or metastatic HER2-positive gastroesophageal junction adenocarcinoma. In November 2023, the FDA updated this indication to restrict use to patients whose tumors express PD-L1 (CPS ≥ 1), as determined by an FDA-approved test.",
             "source_type": "FDA",
-            "citation": "Merck Sharp & Dohme Corp. Keytruda (pembrolizumab) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/125514s097lbl.pdf. Revised May 2021. Accessed May 6, 2021.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/125514s097lbl.pdf",
+            "citation": "Merck Sharp & Dohme Corp. Keytruda (pembrolizumab) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/125514s148lbl.pdf. Revised November 2023. Accessed December 5, 2023.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/125514s148lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2020-05-01",
-            "last_updated": "2021-05-06",
+            "publication_date": "2023-11-08",
+            "last_updated": "2023-12-05",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25222,6 +25854,7 @@
             "nct": "",
             "publication_date": "2010-06-17",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "ESR1 Amplification"
         },
         {
@@ -25249,6 +25882,7 @@
             "nct": "",
             "publication_date": "2008-09-12",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "FBXW7 Deletion"
         },
         {
@@ -25276,6 +25910,7 @@
             "nct": "",
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "FGFR1 Amplification"
         },
         {
@@ -25303,6 +25938,7 @@
             "nct": "",
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "FGFR1 Amplification"
         },
         {
@@ -25330,6 +25966,7 @@
             "nct": "",
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "FGFR1 Amplification"
         },
         {
@@ -25357,6 +25994,7 @@
             "nct": "",
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "FGFR1 Amplification"
         },
         {
@@ -25384,6 +26022,7 @@
             "nct": "",
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "FGFR2 Amplification"
         },
         {
@@ -25411,6 +26050,7 @@
             "nct": "",
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "FGFR2 Amplification"
         },
         {
@@ -25438,6 +26078,7 @@
             "nct": "",
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "FGFR2 Amplification"
         },
         {
@@ -25465,6 +26106,7 @@
             "nct": "",
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "FGFR2 Amplification"
         },
         {
@@ -25492,6 +26134,7 @@
             "nct": "",
             "publication_date": "2014-06-17",
             "last_updated": "2019-08-09",
+            "_deprecated": false,
             "feature_display": "HIF1a Amplification"
         },
         {
@@ -25519,6 +26162,7 @@
             "nct": "",
             "publication_date": "2017-01-05",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "KEAP1 Deletion"
         },
         {
@@ -25546,6 +26190,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "KIT Amplification"
         },
         {
@@ -25573,6 +26218,7 @@
             "nct": "",
             "publication_date": "2010-12-07",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "MDM2 Amplification"
         },
         {
@@ -25600,6 +26246,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "MET Amplification"
         },
         {
@@ -25627,6 +26274,7 @@
             "nct": "",
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "MET Amplification"
         },
         {
@@ -25654,6 +26302,7 @@
             "nct": "NCT01865747",
             "publication_date": "2015-11-05",
             "last_updated": "2019-08-12",
+            "_deprecated": false,
             "feature_display": "MET Amplification"
         },
         {
@@ -25672,15 +26321,16 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "Clinical trial",
-            "description": "A phase I trial of crizotinib in 40 patients with MET amplified advanced NSCLC showed a 33% response rate.",
-            "source_type": "Abstract",
-            "citation": "Camidge DR, Otterson GA, Clark JW, et al. Crizotinib in patients (pts) with MET-amplified non-small cell lung cancer (NSCLC): Updated safety and efficacy findings from a phase 1 trial. JCO. 2018; 36(15_suppl):9062-9062.",
-            "url": "https://doi.org/10.1200/JCO.2018.36.15_suppl.9062",
-            "doi": "10.1200/JCO.2018.36.15_suppl.9062",
-            "pmid": "",
-            "nct": "NCT00585195",
-            "publication_date": "2018-06-01",
-            "last_updated": "2019-04-16",
+            "description": "",
+            "source_type": "Journal",
+            "citation": "A phase 1 trial of crizotinib (NCT00585195) in patients with MET amplified non-small cell lung cancer observed an objective response rate of 6 out of 15 patients with MET amplified gene copy number greater than or equal to 6. The study enrolled 38 patients with MET-to-CEP7 ratios greater than equal to 1.8 by local FISH testing.",
+            "url": "https://doi.org/10.1016/j.jtho.2021.02.010",
+            "doi": "10.1016/j.jtho.2021.02.010",
+            "pmid": "33676017",
+            "nct": "",
+            "publication_date": "2021-03-04",
+            "last_updated": "2024-03-05",
+            "_deprecated": false,
             "feature_display": "MET Amplification"
         },
         {
@@ -25708,6 +26358,7 @@
             "nct": "",
             "publication_date": "2016-05-06",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "MIR17HG Amplification"
         },
         {
@@ -25735,6 +26386,7 @@
             "nct": "",
             "publication_date": "2016-05-06",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "MIR17HG Deletion"
         },
         {
@@ -25762,6 +26414,7 @@
             "nct": "",
             "publication_date": "2010-09-14",
             "last_updated": "2019-08-08",
+            "_deprecated": false,
             "feature_display": "MRE11 Amplification"
         },
         {
@@ -25789,6 +26442,7 @@
             "nct": "",
             "publication_date": "2011-12-03",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "MYC Amplification"
         },
         {
@@ -25816,6 +26470,7 @@
             "nct": "",
             "publication_date": "2015-04-09",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "MYC Amplification"
         },
         {
@@ -25843,6 +26498,7 @@
             "nct": "",
             "publication_date": "2007-05-07",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "PAK1 Amplification"
         },
         {
@@ -25870,6 +26526,7 @@
             "nct": "",
             "publication_date": "2007-05-07",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "PAK1 Amplification"
         },
         {
@@ -25897,6 +26554,7 @@
             "nct": "",
             "publication_date": "2018-01-04",
             "last_updated": "2018-11-29",
+            "_deprecated": false,
             "feature_display": "PBRM1 Deletion"
         },
         {
@@ -25924,6 +26582,7 @@
             "nct": "NCT00876122",
             "publication_date": "2015-01-05",
             "last_updated": "2019-01-29",
+            "_deprecated": false,
             "feature_display": "PIK3CA Amplification"
         },
         {
@@ -25951,6 +26610,7 @@
             "nct": "",
             "publication_date": "2014-12-16",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -25978,6 +26638,7 @@
             "nct": "",
             "publication_date": "2017-02-21",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -26005,6 +26666,7 @@
             "nct": "",
             "publication_date": "2014-04-09",
             "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -26032,33 +26694,7 @@
             "nct": "",
             "publication_date": "2016-02-04",
             "last_updated": "2019-03-07",
-            "feature_display": "PTEN Deletion"
-        },
-        {
-            "feature_type": "Copy Number",
-            "gene": "PTEN",
-            "direction": "Deletion",
-            "cytoband": "",
-            "disease": "Uterine Leiomyoma",
-            "context": "",
-            "oncotree_term": "Uterine Leiomyoma",
-            "oncotree_code": "ULM",
-            "therapy_name": "Pembrolizumab",
-            "therapy_strategy": "PD-1/PD-L1 inhibition",
-            "therapy_type": "Immunotherapy",
-            "therapy_sensitivity": "",
-            "therapy_resistance": 1,
-            "favorable_prognosis": "",
-            "predictive_implication": "Clinical evidence",
-            "description": "PTEN loss may predict resistance to immune checkpoint blockade",
-            "source_type": "Journal",
-            "citation": "Peng W, Chen JQ, Liu C, et al. Loss of PTEN Promotes Resistance to T Cell-Mediated Immunotherapy. Cancer Discov. 2016;6(2):202-16.",
-            "url": "https://doi.org/10.1158/2159-8290.CD-15-0283",
-            "doi": "10.1158/2159-8290.CD-15-0283",
-            "pmid": 26645196,
-            "nct": "",
-            "publication_date": "2016-02-04",
-            "last_updated": "2019-03-07",
+            "_deprecated": false,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -26086,6 +26722,7 @@
             "nct": "NCT00903175",
             "publication_date": "2019-01-15",
             "last_updated": "2019-08-12",
+            "_deprecated": false,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -26113,6 +26750,7 @@
             "nct": "NCT00903175",
             "publication_date": "2019-01-15",
             "last_updated": "2019-08-12",
+            "_deprecated": false,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -26140,6 +26778,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "RB1 Deletion"
         },
         {
@@ -26167,6 +26806,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "TP53 Deletion"
         },
         {
@@ -26194,6 +26834,7 @@
             "nct": "",
             "publication_date": "2011-12-29",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "TPX2 Amplification"
         },
         {
@@ -26219,6 +26860,7 @@
             "nct": "",
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "MSI-High"
         },
         {
@@ -26244,6 +26886,7 @@
             "nct": "",
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
+            "_deprecated": false,
             "feature_display": "MSI-High"
         },
         {
@@ -26269,6 +26912,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "MSI-High"
         },
         {
@@ -26294,6 +26938,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "MSI-High"
         },
         {
@@ -26319,6 +26964,7 @@
             "nct": "",
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "MSI-High"
         },
         {
@@ -26344,6 +26990,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "MSI-High"
         },
         {
@@ -26369,6 +27016,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS10a (version 3.4)"
         },
         {
@@ -26394,6 +27042,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS10b (version 3.4)"
         },
         {
@@ -26419,6 +27068,7 @@
             "nct": "",
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS10a (version 3.4)"
         },
         {
@@ -26444,6 +27094,7 @@
             "nct": "",
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS10b (version 3.4)"
         },
         {
@@ -26469,6 +27120,7 @@
             "nct": "",
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS10a (version 3.4)"
         },
         {
@@ -26494,6 +27146,7 @@
             "nct": "",
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS10b (version 3.4)"
         },
         {
@@ -26519,6 +27172,7 @@
             "nct": "",
             "publication_date": "2016-06-10",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS2 (version 3.4)"
         },
         {
@@ -26544,6 +27198,7 @@
             "nct": "",
             "publication_date": "2016-06-10",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS2 (version 3.4)"
         },
         {
@@ -26569,6 +27224,7 @@
             "nct": "",
             "publication_date": "2015-10-29",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -26594,6 +27250,7 @@
             "nct": "",
             "publication_date": "2015-10-29",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -26619,6 +27276,7 @@
             "nct": "",
             "publication_date": "2015-10-29",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -26644,6 +27302,7 @@
             "nct": "",
             "publication_date": "2015-10-29",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -26669,6 +27328,7 @@
             "nct": "",
             "publication_date": "2015-10-29",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -26694,6 +27354,7 @@
             "nct": "",
             "publication_date": "2015-02-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -26719,6 +27380,7 @@
             "nct": "",
             "publication_date": "2015-03-12",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS4 (version 3.4)"
         },
         {
@@ -26744,6 +27406,7 @@
             "nct": "",
             "publication_date": "2015-03-12",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS4 (version 3.4)"
         },
         {
@@ -26769,6 +27432,7 @@
             "nct": "",
             "publication_date": "2016-04-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS5 (version 3.4)"
         },
         {
@@ -26794,6 +27458,7 @@
             "nct": "",
             "publication_date": "2020-11-01",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -26819,6 +27484,7 @@
             "nct": "",
             "publication_date": "2020-11-01",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -26844,6 +27510,7 @@
             "nct": "",
             "publication_date": "2020-11-01",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -26871,6 +27538,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "High mutational burden"
         },
         {
@@ -26898,6 +27566,7 @@
             "nct": "",
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "High mutational burden"
         },
         {
@@ -26925,6 +27594,7 @@
             "nct": "",
             "publication_date": "2015-03-12",
             "last_updated": "2017-03-12",
+            "_deprecated": false,
             "feature_display": "High mutational burden"
         },
         {
@@ -26952,6 +27622,7 @@
             "nct": "",
             "publication_date": "2014-12-04",
             "last_updated": "2017-03-12",
+            "_deprecated": false,
             "feature_display": "High mutational burden"
         },
         {
@@ -26979,6 +27650,7 @@
             "nct": "",
             "publication_date": "2015-09-10",
             "last_updated": "2017-03-12",
+            "_deprecated": false,
             "feature_display": "High mutational burden"
         },
         {
@@ -27006,6 +27678,7 @@
             "nct": "",
             "publication_date": "2020-10-01",
             "last_updated": "2021-09-16",
+            "_deprecated": false,
             "feature_display": "High mutational burden"
         },
         {
@@ -27013,8 +27686,8 @@
             "technique": "shRNA",
             "gene": "ATM",
             "disease": "Colorectal Cancer",
-            "oncotree_term": "COADREAD",
-            "oncotree_code": "Colorectal Adenocarcinoma",
+            "oncotree_term": "Colorectal Adenocarcinoma",
+            "oncotree_code": "COADREAD",
             "context": "",
             "therapy_name": "Olaparib",
             "therapy_strategy": "PARP inhibition",
@@ -27032,6 +27705,7 @@
             "nct": "",
             "publication_date": "2017-04-01",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "ATM knockdown (shRNA)"
         },
         {
@@ -27058,6 +27732,7 @@
             "nct": "",
             "publication_date": "2017-08-07",
             "last_updated": "2019-04-16",
+            "_deprecated": false,
             "feature_display": "B2M knockdown (CRISPR-Cas9)"
         },
         {
@@ -27084,6 +27759,7 @@
             "nct": "",
             "publication_date": "2014-01-05",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CDK12 knockdown (shRNA)"
         },
         {
@@ -27110,6 +27786,7 @@
             "nct": "",
             "publication_date": "2014-03-08",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CDK12 knockdown (siRNA)"
         },
         {
@@ -27136,6 +27813,7 @@
             "nct": "",
             "publication_date": "2016-10-25",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "CPT1A knockdown (shRNA)"
         },
         {
@@ -27162,6 +27840,7 @@
             "nct": "",
             "publication_date": "2011-11-03",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD17 knockdown (shRNA)"
         },
         {
@@ -27188,6 +27867,7 @@
             "nct": "",
             "publication_date": "2011-11-03",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD17 knockdown (shRNA)"
         },
         {
@@ -27214,6 +27894,7 @@
             "nct": "",
             "publication_date": "2011-11-03",
             "last_updated": "2017-11-03",
+            "_deprecated": false,
             "feature_display": "RAD50 knockdown (shRNA)"
         },
         {
@@ -27240,6 +27921,7 @@
             "nct": "",
             "publication_date": "2017-08-07",
             "last_updated": "2019-04-16",
+            "_deprecated": false,
             "feature_display": "TAP2 knockdown (CRISPR-Cas9)"
         },
         {
@@ -27266,6 +27948,7 @@
             "nct": "",
             "publication_date": "2016-08-31",
             "last_updated": "2019-04-30",
+            "_deprecated": false,
             "feature_display": "PPARGC1A knockdown (CRSPR-Cas9)"
         },
         {
@@ -27291,6 +27974,7 @@
             "nct": "",
             "publication_date": "2018-07-16",
             "last_updated": "2018-09-01",
+            "_deprecated": false,
             "feature_display": "Whole genome doubling"
         },
         {
@@ -27326,6 +28010,7 @@
             "nct": "",
             "publication_date": "2022-03-01",
             "last_updated": "2022-07-07",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -27361,6 +28046,7 @@
             "nct": "",
             "publication_date": "2022-05-01",
             "last_updated": "2022-07-07",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -27396,6 +28082,7 @@
             "nct": "",
             "publication_date": "2022-05-01",
             "last_updated": "2022-07-07",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -27431,6 +28118,7 @@
             "nct": "",
             "publication_date": "2022-05-01",
             "last_updated": "2022-07-07",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -27466,6 +28154,7 @@
             "nct": "",
             "publication_date": "2022-05-01",
             "last_updated": "2022-07-07",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -27491,6 +28180,7 @@
             "nct": "NCT01876511",
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "MSI-High"
         },
         {
@@ -27516,6 +28206,7 @@
             "nct": "",
             "publication_date": "2021-03-01",
             "last_updated": "2022-07-07",
+            "_deprecated": false,
             "feature_display": "MSI-High"
         },
         {
@@ -27553,6 +28244,7 @@
             "nct": "NCT00516373",
             "publication_date": "2009-07-09",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -27590,6 +28282,7 @@
             "nct": "NCT00516373",
             "publication_date": "2009-07-09",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -27627,6 +28320,7 @@
             "nct": "NCT00516373",
             "publication_date": "2009-07-09",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -27664,6 +28358,7 @@
             "nct": "NCT00516373",
             "publication_date": "2009-07-09",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -27701,6 +28396,7 @@
             "nct": "NCT00516373",
             "publication_date": "2009-07-09",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -27738,6 +28434,7 @@
             "nct": "NCT00516373",
             "publication_date": "2009-07-09",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -27764,6 +28461,7 @@
             "nct": "",
             "publication_date": "2020-04-15",
             "last_updated": "2023-10-05",
+            "_deprecated": false,
             "feature_display": "RB1 knockdown (shRNA)"
         },
         {
@@ -27790,12 +28488,13 @@
             "nct": "",
             "publication_date": "2010-05-07",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "USP11 knockdown (siRNA)"
         },
         {
             "feature_type": "Rearrangement",
             "gene1": "ALK",
-            "gene2": "EML4",
+            "gene2": "",
             "rearrangement_type": "Fusion",
             "locus": "",
             "disease": "Inflammatory Myofibroblastic Tumor (IMT)",
@@ -27809,16 +28508,17 @@
             "therapy_resistance": "",
             "favorable_prognosis": "",
             "predictive_implication": "FDA-Approved",
-            "description": "The U.S. Food and Drug Administration (FDA) granted approval to crizotinib for adult and pediatric patients 1 year of age or older with unresectable, recurrent, or refactory inflammatory anaplastic lymphoma kinase (ALK)-positive myofibroblastic tumors (IMT).",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to crizotinib for the treatment of adult and pediatric patients 1 year of age or older with unresectable, recurrent, or refactory inflammatory anaplastic lymphoma kinase (ALK)-positive myofibroblastic tumors (IMT).",
             "source_type": "FDA",
             "citation": "Pfizer, Inc. Xalkori (crizotinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2022/202570s033lbl.pdf. Revised July 2022. Accessed August 4th, 2022.",
             "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2022/202570s033lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
-            "publication_date": "2022-07-01",
-            "last_updated": "2022-08-04",
-            "feature_display": "ALK--EML4 Fusion"
+            "publication_date": "2022-07-14",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
+            "feature_display": "ALK Fusion"
         },
         {
             "feature_type": "Somatic Variant",
@@ -27853,6 +28553,7 @@
             "nct": "",
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Nonsense)"
         },
         {
@@ -27888,6 +28589,7 @@
             "nct": "",
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Frameshift)"
         },
         {
@@ -27923,6 +28625,7 @@
             "nct": "",
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Nonsense)"
         },
         {
@@ -27958,6 +28661,7 @@
             "nct": "",
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Frameshift)"
         },
         {
@@ -27993,6 +28697,7 @@
             "nct": "",
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Nonsense)"
         },
         {
@@ -28028,6 +28733,7 @@
             "nct": "",
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Frameshift)"
         },
         {
@@ -28063,6 +28769,7 @@
             "nct": "",
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Nonsense)"
         },
         {
@@ -28098,6 +28805,7 @@
             "nct": "",
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Frameshift)"
         },
         {
@@ -28133,6 +28841,7 @@
             "nct": "",
             "publication_date": "2018-12-12",
             "last_updated": "2023-10-31",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Nonsense)"
         },
         {
@@ -28168,6 +28877,7 @@
             "nct": "",
             "publication_date": "2018-12-12",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Frameshift)"
         },
         {
@@ -28203,6 +28913,7 @@
             "nct": "",
             "publication_date": "2020-04-15",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "RB1 (Nonsense)"
         },
         {
@@ -28238,6 +28949,7 @@
             "nct": "",
             "publication_date": "2020-04-15",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "RB1 (Frameshift)"
         },
         {
@@ -28266,6 +28978,7 @@
             "nct": "",
             "publication_date": "2015-02-01",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "ATRX Deletion"
         },
         {
@@ -28294,6 +29007,7 @@
             "nct": "",
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA1 Deletion"
         },
         {
@@ -28322,6 +29036,7 @@
             "nct": "",
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA2 Deletion"
         },
         {
@@ -28350,6 +29065,7 @@
             "nct": "",
             "publication_date": "2018-12-12",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "BRCA2 Deletion"
         },
         {
@@ -28378,6 +29094,7 @@
             "nct": "",
             "publication_date": "2017-03-10",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "CDKN2A Deletion"
         },
         {
@@ -28406,6 +29123,7 @@
             "nct": "",
             "publication_date": "2020-09-01",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "CDKN2C Deletion"
         },
         {
@@ -28434,6 +29152,7 @@
             "nct": "",
             "publication_date": "2012-07-01",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "MAP2K4 Amplification"
         },
         {
@@ -28462,6 +29181,7 @@
             "nct": "",
             "publication_date": "2012-07-01",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "MAP2K4 Amplification"
         },
         {
@@ -28490,6 +29210,7 @@
             "nct": "",
             "publication_date": "2012-07-01",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "MAP2K4 Amplification"
         },
         {
@@ -28518,6 +29239,7 @@
             "nct": "",
             "publication_date": "2012-07-01",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "MAPK7 Amplification"
         },
         {
@@ -28546,6 +29268,7 @@
             "nct": "",
             "publication_date": "2009-03-17",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "MYOCD Amplification"
         },
         {
@@ -28574,6 +29297,7 @@
             "nct": "",
             "publication_date": "2005-08-01",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "PDGFRA Amplification"
         },
         {
@@ -28602,6 +29326,7 @@
             "nct": "",
             "publication_date": "2017-02-28",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -28630,6 +29355,7 @@
             "nct": "",
             "publication_date": "2017-02-28",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -28658,6 +29384,7 @@
             "nct": "",
             "publication_date": "2020-04-15",
             "last_updated": "2022-08-04",
+            "_deprecated": false,
             "feature_display": "RB1 Deletion"
         },
         {
@@ -28686,6 +29413,7 @@
             "nct": "",
             "publication_date": "2022-08-01",
             "last_updated": "2022-09-08",
+            "_deprecated": false,
             "feature_display": "FGFR1"
         },
         {
@@ -28714,6 +29442,7 @@
             "nct": "",
             "publication_date": "2022-09-01",
             "last_updated": "2022-10-06",
+            "_deprecated": false,
             "feature_display": "FGFR2"
         },
         {
@@ -28742,6 +29471,7 @@
             "nct": "",
             "publication_date": "2022-09-01",
             "last_updated": "2022-12-01",
+            "_deprecated": false,
             "feature_display": "RET Fusion"
         },
         {
@@ -28777,6 +29507,7 @@
             "nct": "",
             "publication_date": "2022-12-01",
             "last_updated": "2023-01-05",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -28812,6 +29543,7 @@
             "nct": "",
             "publication_date": "2022-12-01",
             "last_updated": "2023-01-05",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -28847,6 +29579,7 @@
             "nct": "",
             "publication_date": "2022-12-01",
             "last_updated": "2023-01-05",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132G (Missense)"
         },
         {
@@ -28882,6 +29615,7 @@
             "nct": "",
             "publication_date": "2022-12-01",
             "last_updated": "2023-01-05",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132S (Missense)"
         },
         {
@@ -28917,6 +29651,7 @@
             "nct": "",
             "publication_date": "2022-12-01",
             "last_updated": "2023-01-05",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132L (Missense)"
         },
         {
@@ -28927,7 +29662,7 @@
             "end_position": 25398285,
             "reference_allele": "C",
             "alternate_allele": "A",
-            "cdna_change": "c.35G>T",
+            "cdna_change": "c.34G>T",
             "protein_change": "p.G12C",
             "variant_annotation": "Missense",
             "exon": 2,
@@ -28951,7 +29686,8 @@
             "pmid": "",
             "nct": "",
             "publication_date": "2022-12-01",
-            "last_updated": "2023-01-05",
+            "last_updated": "2023-11-30",
+            "_deprecated": false,
             "feature_display": "KRAS p.G12C (Missense)"
         },
         {
@@ -28979,6 +29715,7 @@
             "nct": "",
             "publication_date": "2023-01-19",
             "last_updated": "2023-02-02",
+            "_deprecated": false,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -29014,6 +29751,7 @@
             "nct": "",
             "publication_date": "2023-01-27",
             "last_updated": "2023-02-02",
+            "_deprecated": false,
             "feature_display": "ESR1"
         },
         {
@@ -29030,7 +29768,7 @@
             "exon": 15,
             "rsid": "rs113488022",
             "disease": "Low-grade glioma",
-            "context": "Unresctable or metastatic",
+            "context": "Unresectable or metastatic",
             "oncotree_term": "Low-Grade Glioma, NOS",
             "oncotree_code": "LGGNOS",
             "therapy_name": "Dabrafenib + Trametinib",
@@ -29049,6 +29787,7 @@
             "nct": "",
             "publication_date": "2023-03-16",
             "last_updated": "2023-04-06",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -29084,6 +29823,7 @@
             "nct": "",
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-05",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -29119,6 +29859,7 @@
             "nct": "",
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-05",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -29155,6 +29896,7 @@
             "nct": "",
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-05",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -29191,6 +29933,7 @@
             "nct": "",
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-05",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -29227,6 +29970,7 @@
             "nct": "",
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-05",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -29263,6 +30007,7 @@
             "nct": "",
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-05",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -29300,6 +30045,7 @@
             "nct": "",
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -29337,6 +30083,7 @@
             "nct": "",
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -29373,6 +30120,7 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "ATM"
         },
         {
@@ -29409,6 +30157,7 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "ATR"
         },
         {
@@ -29445,6 +30194,7 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -29481,6 +30231,7 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -29517,6 +30268,7 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "CDK12"
         },
         {
@@ -29553,6 +30305,7 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "CHEK2"
         },
         {
@@ -29589,6 +30342,7 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "FANCA"
         },
         {
@@ -29625,6 +30379,7 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "MLH1"
         },
         {
@@ -29661,7 +30416,7 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
-            "feature_display": "MRE11A"
+            "_deprecated": true
         },
         {
             "feature_type": "Somatic Variant",
@@ -29697,6 +30452,7 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "NBN"
         },
         {
@@ -29733,6 +30489,7 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "PALB2"
         },
         {
@@ -29769,6 +30526,7 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "RAD51C"
         },
         {
@@ -29806,6 +30564,7 @@
             "nct": "",
             "publication_date": "2023-08-11",
             "last_updated": "2023-09-06",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -29842,6 +30601,7 @@
             "nct": "",
             "publication_date": "2023-08-11",
             "last_updated": "2023-09-06",
+            "_deprecated": false,
             "feature_display": "BRCA1"
         },
         {
@@ -29879,6 +30639,7 @@
             "nct": "",
             "publication_date": "2023-08-11",
             "last_updated": "2023-09-06",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -29915,6 +30676,7 @@
             "nct": "",
             "publication_date": "2023-08-11",
             "last_updated": "2023-09-06",
+            "_deprecated": false,
             "feature_display": "BRCA2"
         },
         {
@@ -29940,6 +30702,7 @@
             "nct": "",
             "publication_date": "2023-07-31",
             "last_updated": "2023-09-06",
+            "_deprecated": false,
             "feature_display": "MSI-High"
         },
         {
@@ -29976,6 +30739,7 @@
             "nct": "",
             "publication_date": "2019-01-22",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "TP53"
         },
         {
@@ -30012,6 +30776,7 @@
             "nct": "",
             "publication_date": "2018-07-13",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "RB1"
         },
         {
@@ -30040,6 +30805,7 @@
             "nct": "",
             "publication_date": "2018-07-13",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "FGFR1 Amplification"
         },
         {
@@ -30068,6 +30834,7 @@
             "nct": "",
             "publication_date": "2018-07-13",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "FGFR1 Amplification"
         },
         {
@@ -30104,6 +30871,7 @@
             "nct": "",
             "publication_date": "2021-12-03",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "RB1"
         },
         {
@@ -30132,6 +30900,7 @@
             "nct": "",
             "publication_date": "2019-01-09",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "MYC Amplification"
         },
         {
@@ -30160,6 +30929,7 @@
             "nct": "",
             "publication_date": "2019-01-09",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "CCNE1 Amplification"
         },
         {
@@ -30188,6 +30958,7 @@
             "nct": "",
             "publication_date": "2019-01-09",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "CDK4 Amplification"
         },
         {
@@ -30216,6 +30987,7 @@
             "nct": "",
             "publication_date": "2019-01-09",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -30244,6 +31016,7 @@
             "nct": "",
             "publication_date": "2019-01-09",
             "last_updated": "2023-07-06",
+            "_deprecated": false,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -30272,6 +31045,7 @@
             "nct": "",
             "publication_date": "2017-07-25",
             "last_updated": "2023-07-27",
+            "_deprecated": false,
             "feature_display": "BAP1 Deletion"
         },
         {
@@ -30300,6 +31074,7 @@
             "nct": "",
             "publication_date": "2017-07-25",
             "last_updated": "2023-07-27",
+            "_deprecated": false,
             "feature_display": "FANCA Deletion"
         },
         {
@@ -30328,6 +31103,7 @@
             "nct": "",
             "publication_date": "2017-07-25",
             "last_updated": "2023-07-27",
+            "_deprecated": false,
             "feature_display": "BARD1 Deletion"
         },
         {
@@ -30356,6 +31132,7 @@
             "nct": "",
             "publication_date": "2017-07-25",
             "last_updated": "2023-07-27",
+            "_deprecated": false,
             "feature_display": "CHEK2 Deletion"
         },
         {
@@ -30384,6 +31161,7 @@
             "nct": "",
             "publication_date": "2017-07-25",
             "last_updated": "2023-07-27",
+            "_deprecated": false,
             "feature_display": "TP53 Deletion"
         },
         {
@@ -30412,6 +31190,7 @@
             "nct": "",
             "publication_date": "2017-07-25",
             "last_updated": "2023-07-27",
+            "_deprecated": false,
             "feature_display": "ATM Deletion"
         },
         {
@@ -30441,6 +31220,7 @@
             "nct": "",
             "publication_date": "2023-09-26",
             "last_updated": "2023-11-01",
+            "_deprecated": false,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -30476,6 +31256,7 @@
             "nct": "",
             "publication_date": "2023-10-24",
             "last_updated": "2023-11-01",
+            "_deprecated": false,
             "feature_display": "IDH1"
         },
         {
@@ -30511,6 +31292,7 @@
             "nct": "",
             "publication_date": "2023-10-24",
             "last_updated": "2023-11-01",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -30546,6 +31328,7 @@
             "nct": "",
             "publication_date": "2023-10-24",
             "last_updated": "2023-11-01",
+            "_deprecated": false,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -30581,6 +31364,7 @@
             "nct": "",
             "publication_date": "2023-10-11",
             "last_updated": "2023-11-01",
+            "_deprecated": false,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -30616,6 +31400,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "FLT3 p.D835A (Missense)"
         },
         {
@@ -30651,6 +31436,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "FLT3 p.D835E (Missense)"
         },
         {
@@ -30686,6 +31472,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "FLT3 p.D835H (Missense)"
         },
         {
@@ -30721,6 +31508,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "FLT3 p.D835Y (Missense)"
         },
         {
@@ -30756,6 +31544,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "FLT3 (Missense)"
         },
         {
@@ -30791,6 +31580,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "FLT3 (Nonsense)"
         },
         {
@@ -30826,6 +31616,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "FLT3 (Frameshift)"
         },
         {
@@ -30861,6 +31652,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "FLT3 (Splice Site)"
         },
         {
@@ -30896,6 +31688,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
+            "_deprecated": false,
             "feature_display": "NPM1 p.W288Cfs*12 (Frameshift)"
         },
         {
@@ -30931,6 +31724,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-06",
+            "_deprecated": false,
             "feature_display": "SRSF2 p.P95H (Missense)"
         },
         {
@@ -30966,6 +31760,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-06",
+            "_deprecated": false,
             "feature_display": "SRSF2 p.P95L (Missense)"
         },
         {
@@ -31001,6 +31796,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-06",
+            "_deprecated": false,
             "feature_display": "SRSF2 p.P95R (Missense)"
         },
         {
@@ -31036,6 +31832,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-06",
+            "_deprecated": false,
             "feature_display": "SRSF2 p.P95A (Missense)"
         },
         {
@@ -31071,6 +31868,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-06",
+            "_deprecated": false,
             "feature_display": "SRSF2 p.P95_R102del (Deletion)"
         },
         {
@@ -31106,6 +31904,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "WT1 (Nonsense)"
         },
         {
@@ -31141,6 +31940,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "WT1 (Frameshift)"
         },
         {
@@ -31176,6 +31976,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "WT1 (Splice Site)"
         },
         {
@@ -31211,6 +32012,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "U2AF1 p.S34A (Missense)"
         },
         {
@@ -31246,6 +32048,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "U2AF1 p.S34F (Missense)"
         },
         {
@@ -31281,6 +32084,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "U2AF1 p.S34F (Missense)"
         },
         {
@@ -31316,6 +32120,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "U2AF1 p.S34Y (Missense)"
         },
         {
@@ -31351,6 +32156,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "U2AF1 p.Q157P (Missense)"
         },
         {
@@ -31386,6 +32192,7 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "U2AF1 p.Q157P (Missense)"
         },
         {
@@ -31421,7 +32228,884 @@
             "nct": "",
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
+            "_deprecated": false,
             "feature_display": "U2AF1 p.Q157R (Missense)"
+        },
+        {
+            "feature_type": "Rearrangement",
+            "gene1": "ROS1",
+            "gene2": "",
+            "rearrangement_type": "",
+            "locus": "",
+            "disease": "Non-Small Cell Lung Cancer",
+            "context": "Locally advanced or metastatic",
+            "oncotree_term": "Non-Small Cell Lung Cancer",
+            "oncotree_code": "NSCLC",
+            "therapy_name": "Repotrectinib",
+            "therapy_strategy": "ROS inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to repotrectinib for the treatment of patients with locally advanced or metastatic ROS1-positive non-small cell lung cancer (NSCLC).",
+            "source_type": "FDA",
+            "citation": "Bristol-Myers Squibb Company. Augtyro (repotrectinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218213s000lbl.pdf. Revised November 2023. Accessed December 5, 2023.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218213s000lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2023-11-15",
+            "last_updated": "2023-12-05",
+            "_deprecated": true
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "PIK3CA",
+            "chromosome": 3,
+            "start_position": "",
+            "end_position": "",
+            "reference_allele": "",
+            "alternate_allele": "",
+            "cdna_change": "",
+            "protein_change": "",
+            "variant_annotation": "",
+            "exon": "",
+            "rsid": "",
+            "disease": "Breast cancer",
+            "context": "Locally advanced or metastatic",
+            "oncotree_term": "Invasive Breast Carcinoma",
+            "oncotree_code": "BRCA",
+            "therapy_name": "Capivasertib + Fulvestrant",
+            "therapy_strategy": "PI3K/AKT/mTOR inhibition + ER signaling inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to capivasertib in combination with fulvestrant for the treatment of adult patients with locally advanced or metastatic hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative breast cancer with one or more PIK3CA/AKT1/PTEN-alterations, as detected by an FDA-approved test, following progression on at least one endocrine-based regimen in the metastatic setting or recurrence on or within 12 months of completing adjuvant therapy. The efficacy of capivasertib in combination with fulvestrant was evaluated in CAPItello-291 (NCT04305496), which described biomarker eligibility as PIK3CA/AKT1 activating mutations or PTEN loss of function alterations.",
+            "source_type": "FDA",
+            "citation": "AstraZeneca Pharmaceuticals, LP. Truqap (capivasertib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218197s000lbl.pdf. Revised November 2023. Accessed December 5, 2023.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218197s000lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2023-11-16",
+            "last_updated": "2023-12-07",
+            "_deprecated": false,
+            "feature_display": "PIK3CA"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "AKT1",
+            "chromosome": 14,
+            "start_position": "",
+            "end_position": "",
+            "reference_allele": "",
+            "alternate_allele": "",
+            "cdna_change": "",
+            "protein_change": "",
+            "variant_annotation": "",
+            "exon": "",
+            "rsid": "",
+            "disease": "Breast cancer",
+            "context": "Locally advanced or metastatic",
+            "oncotree_term": "Invasive Breast Carcinoma",
+            "oncotree_code": "BRCA",
+            "therapy_name": "Capivasertib + Fulvestrant",
+            "therapy_strategy": "PI3K/AKT/mTOR inhibition + ER signaling inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to capivasertib in combination with fulvestrant for the treatment of adult patients with locally advanced or metastatic hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative breast cancer with one or more PIK3CA/AKT1/PTEN-alterations, as detected by an FDA-approved test, following progression on at least one endocrine-based regimen in the metastatic setting or recurrence on or within 12 months of completing adjuvant therapy. The efficacy of capivasertib in combination with fulvestrant was evaluated in CAPItello-291 (NCT04305496), which described biomarker eligibility as PIK3CA/AKT1 activating mutations or PTEN loss of function alterations.",
+            "source_type": "FDA",
+            "citation": "AstraZeneca Pharmaceuticals, LP. Truqap (capivasertib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218197s000lbl.pdf. Revised November 2023. Accessed December 5, 2023.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218197s000lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2023-11-16",
+            "last_updated": "2023-12-07",
+            "_deprecated": false,
+            "feature_display": "AKT1"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "PTEN",
+            "chromosome": 10,
+            "start_position": "",
+            "end_position": "",
+            "reference_allele": "",
+            "alternate_allele": "",
+            "cdna_change": "",
+            "protein_change": "",
+            "variant_annotation": "Nonsense",
+            "exon": "",
+            "rsid": "",
+            "disease": "Breast cancer",
+            "context": "Locally advanced or metastatic",
+            "oncotree_term": "Invasive Breast Carcinoma",
+            "oncotree_code": "BRCA",
+            "therapy_name": "Capivasertib + Fulvestrant",
+            "therapy_strategy": "PI3K/AKT/mTOR inhibition + ER signaling inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to capivasertib in combination with fulvestrant for the treatment of adult patients with locally advanced or metastatic hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative breast cancer with one or more PIK3CA/AKT1/PTEN-alterations, as detected by an FDA-approved test, following progression on at least one endocrine-based regimen in the metastatic setting or recurrence on or within 12 months of completing adjuvant therapy. The efficacy of capivasertib in combination with fulvestrant was evaluated in CAPItello-291 (NCT04305496), which described biomarker eligibility as PIK3CA/AKT1 activating mutations or PTEN loss of function alterations.",
+            "source_type": "FDA",
+            "citation": "AstraZeneca Pharmaceuticals, LP. Truqap (capivasertib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218197s000lbl.pdf. Revised November 2023. Accessed December 5, 2023.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218197s000lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2023-11-16",
+            "last_updated": "2023-12-07",
+            "_deprecated": false,
+            "feature_display": "PTEN (Nonsense)"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "PTEN",
+            "chromosome": 10,
+            "start_position": "",
+            "end_position": "",
+            "reference_allele": "",
+            "alternate_allele": "",
+            "cdna_change": "",
+            "protein_change": "",
+            "variant_annotation": "Frameshift",
+            "exon": "",
+            "rsid": "",
+            "disease": "Breast cancer",
+            "context": "Locally advanced or metastatic",
+            "oncotree_term": "Invasive Breast Carcinoma",
+            "oncotree_code": "BRCA",
+            "therapy_name": "Capivasertib + Fulvestrant",
+            "therapy_strategy": "PI3K/AKT/mTOR inhibition + ER signaling inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to capivasertib in combination with fulvestrant for the treatment of adult patients with locally advanced or metastatic hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative breast cancer with one or more PIK3CA/AKT1/PTEN-alterations, as detected by an FDA-approved test, following progression on at least one endocrine-based regimen in the metastatic setting or recurrence on or within 12 months of completing adjuvant therapy. The efficacy of capivasertib in combination with fulvestrant was evaluated in CAPItello-291 (NCT04305496), which described biomarker eligibility as PIK3CA/AKT1 activating mutations or PTEN loss of function alterations.",
+            "source_type": "FDA",
+            "citation": "AstraZeneca Pharmaceuticals, LP. Truqap (capivasertib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218197s000lbl.pdf. Revised November 2023. Accessed December 5, 2023.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218197s000lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2023-11-16",
+            "last_updated": "2023-12-07",
+            "_deprecated": false,
+            "feature_display": "PTEN (Frameshift)"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "PTEN",
+            "chromosome": 10,
+            "start_position": "",
+            "end_position": "",
+            "reference_allele": "",
+            "alternate_allele": "",
+            "cdna_change": "",
+            "protein_change": "",
+            "variant_annotation": "Splice Site",
+            "exon": "",
+            "rsid": "",
+            "disease": "Breast cancer",
+            "context": "Locally advanced or metastatic",
+            "oncotree_term": "Invasive Breast Carcinoma",
+            "oncotree_code": "BRCA",
+            "therapy_name": "Capivasertib + Fulvestrant",
+            "therapy_strategy": "PI3K/AKT/mTOR inhibition + ER signaling inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to capivasertib in combination with fulvestrant for the treatment of adult patients with locally advanced or metastatic hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative breast cancer with one or more PIK3CA/AKT1/PTEN-alterations, as detected by an FDA-approved test, following progression on at least one endocrine-based regimen in the metastatic setting or recurrence on or within 12 months of completing adjuvant therapy. The efficacy of capivasertib in combination with fulvestrant was evaluated in CAPItello-291 (NCT04305496), which described biomarker eligibility as PIK3CA/AKT1 activating mutations or PTEN loss of function alterations.",
+            "source_type": "FDA",
+            "citation": "AstraZeneca Pharmaceuticals, LP. Truqap (capivasertib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218197s000lbl.pdf. Revised November 2023. Accessed December 5, 2023.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218197s000lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2023-11-16",
+            "last_updated": "2023-12-07",
+            "_deprecated": false,
+            "feature_display": "PTEN (Splice Site)"
+        },
+        {
+            "feature_type": "Copy Number",
+            "gene": "PTEN",
+            "direction": "Deletion",
+            "cytoband": "",
+            "disease": "Breast cancer",
+            "context": "Locally advanced or metastatic",
+            "oncotree_term": "Invasive Breast Carcinoma",
+            "oncotree_code": "BRCA",
+            "therapy_name": "Capivasertib + Fulvestrant",
+            "therapy_strategy": "PI3K/AKT/mTOR inhibition + ER signaling inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to capivasertib in combination with fulvestrant for the treatment of adult patients with locally advanced or metastatic hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative breast cancer with one or more PIK3CA/AKT1/PTEN-alterations, as detected by an FDA-approved test, following progression on at least one endocrine-based regimen in the metastatic setting or recurrence on or within 12 months of completing adjuvant therapy. The efficacy of capivasertib in combination with fulvestrant was evaluated in CAPItello-291 (NCT04305496), which described biomarker eligibility as PIK3CA/AKT1 activating mutations or PTEN loss of function alterations.",
+            "source_type": "FDA",
+            "citation": "AstraZeneca Pharmaceuticals, LP. Truqap (capivasertib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218197s000lbl.pdf. Revised November 2023. Accessed December 5, 2023.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218197s000lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2023-11-16",
+            "last_updated": "2023-12-07",
+            "_deprecated": false,
+            "feature_display": "PTEN Deletion"
+        },
+        {
+            "feature_type": "Copy Number",
+            "gene": "ERBB2",
+            "direction": "Amplification",
+            "cytoband": "",
+            "disease": "Breast Cancer",
+            "context": "Advanced or metastatic",
+            "oncotree_term": "Invasive Breast Carcinoma",
+            "oncotree_code": "BRCA",
+            "therapy_name": "Neratinib + Capecitabine",
+            "therapy_strategy": "ER signaling inhibition + Thymidylate synthase inhibitor",
+            "therapy_type": "Targeted therapy + Chemotherapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) approved neratinib in combination with capecitabine for the treatment of adult patients with advanced or metastatic HER2-positive breast cancer who have received two or more prior anti-HER2 based regimens in the metastatic setting.",
+            "source_type": "FDA",
+            "citation": "Puma Biotechnology, Inc. Nerlynx (neratinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/208051s009lbl.pdf. Revised June 2021. Accessed January 11, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/210868s001lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2020-02-25",
+            "last_updated": "2024-01-11",
+            "_deprecated": false,
+            "feature_display": "ERBB2 Amplification"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "BRAF",
+            "chromosome": "7",
+            "start_position": 140453136,
+            "end_position": 140453136,
+            "reference_allele": "A",
+            "alternate_allele": "T",
+            "cdna_change": "c.1799T>A",
+            "protein_change": "p.V600E",
+            "variant_annotation": "Missense",
+            "exon": 15,
+            "rsid": "rs113488022",
+            "disease": "Erdheim-Chester Disease",
+            "context": "",
+            "oncotree_term": "Non-Langerhans Cell Histiocytosis/Erdheim-Chester Disease",
+            "oncotree_code": "ECD",
+            "therapy_name": "Vemurafenib",
+            "therapy_strategy": "B-RAF inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) approved vemurafenib for the treatment of patients with Erdheim-Chester disease and whose tumors harbor a BRAF V600 mutation.",
+            "source_type": "FDA",
+            "citation": "Genentech, Inc. Zelboraf (vemurafenib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/202429s019lbl.pdf. Revised May 2020. Accessed January 30, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/202429s019lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2017-11-06",
+            "last_updated": "2024-01-30",
+            "_deprecated": false,
+            "feature_display": "BRAF p.V600E (Missense)"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "BRAF",
+            "chromosome": "7",
+            "start_position": 140453136,
+            "end_position": 140453137,
+            "reference_allele": "AC",
+            "alternate_allele": "TT",
+            "cdna_change": "c.1798_1799GT>AA",
+            "protein_change": "p.V600K",
+            "variant_annotation": "Missense",
+            "exon": 15,
+            "rsid": "rs121913227",
+            "disease": "Erdheim-Chester Disease",
+            "context": "",
+            "oncotree_term": "Non-Langerhans Cell Histiocytosis/Erdheim-Chester Disease",
+            "oncotree_code": "ECD",
+            "therapy_name": "Vemurafenib",
+            "therapy_strategy": "B-RAF inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) approved vemurafenib for the treatment of patients with Erdheim-Chester disease and whose tumors harbor a BRAF V600 mutation.",
+            "source_type": "FDA",
+            "citation": "Genentech, Inc. Zelboraf (vemurafenib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/202429s019lbl.pdf. Revised May 2020. Accessed January 30, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/202429s019lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2017-11-06",
+            "last_updated": "2024-01-30",
+            "_deprecated": false,
+            "feature_display": "BRAF p.V600K (Missense)"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "EGFR",
+            "chromosome": "7",
+            "start_position": "",
+            "end_position": "",
+            "reference_allele": "",
+            "alternate_allele": "",
+            "cdna_change": "",
+            "protein_change": "",
+            "variant_annotation": "Insertion",
+            "exon": 20,
+            "rsid": "",
+            "disease": "Non-Small Cell Lung Cancer",
+            "context": "Locally advanced or metastatic disease which has progressed on or after platinum-based chemotherapy.",
+            "oncotree_term": "Non-Small Cell Lung Cancer",
+            "oncotree_code": "NSCLC",
+            "therapy_name": "Amivantamab-vmjw + Carboplatin + Pemetrexed",
+            "therapy_strategy": "EGFR inhibition + Platinum-based chemotherapy + Antifolate",
+            "therapy_type": "Targeted therapy + Chemotherapy + Chemotherapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) has granted approval to amivantamab-vmjw in combination with carboplatin and pemetrexed for the first-line treatment of adult patients with locally advanced or metastatic non-small cell lung cancer (NSCLC) with epidermal growth factor receptor (EGFR) exon 20 insertion mutations, as detected by an FDA-approved test.",
+            "source_type": "FDA",
+            "citation": "Janssen Biotech, Inc. Rybrevant (amivantamab-vmjw) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/761210s003lbl.pdf. Revised March 2024. Accessed March 4, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/761210s003lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2024-03-01",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
+            "feature_display": "EGFR Exon 20 (Insertion)"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "EGFR",
+            "chromosome": "7",
+            "start_position": "",
+            "end_position": "",
+            "reference_allele": "",
+            "alternate_allele": "",
+            "cdna_change": "",
+            "protein_change": "",
+            "variant_annotation": "Deletion",
+            "exon": 19,
+            "rsid": "",
+            "disease": "Non-Small Cell Lung Cancer",
+            "context": "",
+            "oncotree_term": "Non-Small Cell Lung Cancer",
+            "oncotree_code": "NSCLC",
+            "therapy_name": "Cisplatin + Osimertinib + Pemetrexed",
+            "therapy_strategy": "Platinum-based chemotherapy + EGFR inhibition + Antifolate",
+            "therapy_type": "Chemotherapy + Targeted therapy + Chemotherapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) has granted approval to osimertinib in combination with platinum-based chemotherapy and pemetrexed for the first-line treatment of adult patients with locally advanced or metastatic non-small cell lung cancer (NSCLC) with epidermal growth factor receptor (EGFR) exon 19 deletions or exon 21 p.L858R variants, as detected by an FDA-approved test. The efficacy of this indication was demonstrated in a randomized, multicenter, open-label trial (FLAURA2 [NCT04035486]), where patients enrolled in the study arm received osimertinib in combination with pemetrexed and investigator's choice of either cisplatin or carboplatin while patients of the control arm received osimertinib monotherapy.",
+            "source_type": "FDA",
+            "citation": "AstraZeneca Pharmaceuticals, LP. Tagrisso (osimertinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/208065s030lbl.pdf. Revised February 2024. Accessed March 4, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/208065s030lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2024-02-16",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
+            "feature_display": "EGFR Exon 19 (Deletion)"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "EGFR",
+            "chromosome": "7",
+            "start_position": 55259515,
+            "end_position": 55259515,
+            "reference_allele": "T",
+            "alternate_allele": "G",
+            "cdna_change": "c.2573T>G",
+            "protein_change": "p.L858R",
+            "variant_annotation": "Missense",
+            "exon": 21,
+            "rsid": "rs121434568",
+            "disease": "Non-Small Cell Lung Cancer",
+            "context": "",
+            "oncotree_term": "Non-Small Cell Lung Cancer",
+            "oncotree_code": "NSCLC",
+            "therapy_name": "Cisplatin + Osimertinib + Pemetrexed",
+            "therapy_strategy": "Platinum-based chemotherapy + EGFR inhibition + Antifolate",
+            "therapy_type": "Chemotherapy + Targeted therapy + Chemotherapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) has granted approval to osimertinib in combination with platinum-based chemotherapy and pemetrexed for the first-line treatment of adult patients with locally advanced or metastatic non-small cell lung cancer (NSCLC) with epidermal growth factor receptor (EGFR) exon 19 deletions or exon 21 p.L858R variants, as detected by an FDA-approved test. The efficacy of this indication was demonstrated in a randomized, multicenter, open-label trial (FLAURA2 [NCT04035486]), where patients enrolled in the study arm received osimertinib in combination with pemetrexed and investigator's choice of either cisplatin or carboplatin while patients of the control arm received osimertinib monotherapy.",
+            "source_type": "FDA",
+            "citation": "AstraZeneca Pharmaceuticals, LP. Tagrisso (osimertinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/208065s030lbl.pdf. Revised February 2024. Accessed March 4, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/208065s030lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2024-02-16",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
+            "feature_display": "EGFR p.L858R (Missense)"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "EGFR",
+            "chromosome": "7",
+            "start_position": "",
+            "end_position": "",
+            "reference_allele": "",
+            "alternate_allele": "",
+            "cdna_change": "",
+            "protein_change": "",
+            "variant_annotation": "Deletion",
+            "exon": 19,
+            "rsid": "",
+            "disease": "Non-Small Cell Lung Cancer",
+            "context": "",
+            "oncotree_term": "Non-Small Cell Lung Cancer",
+            "oncotree_code": "NSCLC",
+            "therapy_name": "Osimertinib",
+            "therapy_strategy": "EGFR inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval for osimertinib for for the first-line treatment of adult patients with metastatic non-small cell lung cancer whose tumors have epidermal growth factor receptor (EGFR) exon 19 deletions or an exon 21 p.L858R variant, as detected by an FDA-approved test.",
+            "source_type": "FDA",
+            "citation": "AstraZeneca Pharmaceuticals, LP. Tagrisso (osimertinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2018/208065s008lbl.pdf. Revised April 2018. Accessed March 4, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2018/208065s008lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2018-04-18",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
+            "feature_display": "EGFR Exon 19 (Deletion)"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "EGFR",
+            "chromosome": "7",
+            "start_position": 55259515,
+            "end_position": 55259515,
+            "reference_allele": "T",
+            "alternate_allele": "G",
+            "cdna_change": "c.2573T>G",
+            "protein_change": "p.L858R",
+            "variant_annotation": "Missense",
+            "exon": 21,
+            "rsid": "rs121434568",
+            "disease": "Non-Small Cell Lung Cancer",
+            "context": "",
+            "oncotree_term": "Non-Small Cell Lung Cancer",
+            "oncotree_code": "NSCLC",
+            "therapy_name": "Osimertinib",
+            "therapy_strategy": "EGFR inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval for osimertinib for for the first-line treatment of adult patients with metastatic non-small cell lung cancer whose tumors have epidermal growth factor receptor (EGFR) exon 19 deletions or an exon 21 p.L858R variant, as detected by an FDA-approved test.",
+            "source_type": "FDA",
+            "citation": "AstraZeneca Pharmaceuticals, LP. Tagrisso (osimertinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2018/208065s008lbl.pdf. Revised April 2018. Accessed March 4, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2018/208065s008lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2018-04-18",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
+            "feature_display": "EGFR p.L858R (Missense)"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "MET",
+            "chromosome": "7",
+            "start_position": "",
+            "end_position": "",
+            "reference_allele": "",
+            "alternate_allele": "",
+            "cdna_change": "",
+            "protein_change": "",
+            "variant_annotation": "Splice Site",
+            "exon": 14,
+            "rsid": "",
+            "disease": "Non-Small Cell Lung Cancer",
+            "context": "Metastatic",
+            "oncotree_term": "Non-Small Cell Lung Cancer",
+            "oncotree_code": "NSCLC",
+            "therapy_name": "Tepotinib",
+            "therapy_strategy": "MET inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted traditional approval to tepotinib for the treatment of adult patients with metastatic non-small cell lung cancer whose tumors harbor MET exon 14 skipping alterations.",
+            "source_type": "FDA",
+            "citation": "EMD Serono, Inc. Tepmetko (tepotinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/214096s003lbl.pdf. Revised February 2024. Accessed March 4, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/214096s003lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2024-02-15",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
+            "feature_display": "MET Exon 14 (Splice Site)"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "MET",
+            "chromosome": "7",
+            "start_position": "",
+            "end_position": "",
+            "reference_allele": "",
+            "alternate_allele": "",
+            "cdna_change": "",
+            "protein_change": "",
+            "variant_annotation": "Deletion",
+            "exon": 14,
+            "rsid": "",
+            "disease": "Non-Small Cell Lung Cancer",
+            "context": "Metastatic",
+            "oncotree_term": "Non-Small Cell Lung Cancer",
+            "oncotree_code": "NSCLC",
+            "therapy_name": "Tepotinib",
+            "therapy_strategy": "MET inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted traditional approval to tepotinib for the treatment of adult patients with metastatic non-small cell lung cancer whose tumors harbor MET exon 14 skipping alterations.",
+            "source_type": "FDA",
+            "citation": "EMD Serono, Inc. Tepmetko (tepotinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/214096s003lbl.pdf. Revised February 2024. Accessed March 4, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/214096s003lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2024-02-15",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
+            "feature_display": "MET Exon 14 (Deletion)"
+        },
+        {
+            "feature_type": "Rearrangement",
+            "gene1": "ALK",
+            "gene2": "",
+            "rearrangement_type": "Fusion",
+            "locus": "",
+            "disease": "Anaplastic large cell lymphoma (ALCL)",
+            "context": "",
+            "oncotree_term": "Anaplastic Large Cell Lymphoma",
+            "oncotree_code": "ALCL",
+            "therapy_name": "Crizotinib",
+            "therapy_strategy": "MET inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to crizotinib for the treatment of pediatric patients 1 year of age or older and young adults with relapsed or refactory, systemic anaplastic large cell lymphoma (ALCL) that is ALK-positive. The safety and efficacy of crizotinib have not been established in older adults with relapsed or refactory systemic ALK-positive ALCL.",
+            "source_type": "FDA",
+            "citation": "Pfizer, Inc. Xalkori (crizotinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/202570s030lbl.pdf. Revised January 2021. Accessed August 4th, 2022.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/202570s030lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2021-01-14",
+            "last_updated": "2024-03-04",
+            "_deprecated": false,
+            "feature_display": "ALK Fusion"
+        },
+        {
+            "feature_type": "Rearrangement",
+            "gene1": "ROS1",
+            "gene2": "",
+            "rearrangement_type": "Fusion",
+            "locus": "",
+            "disease": "Non-Small Cell Lung Cancer",
+            "context": "Metastatic",
+            "oncotree_term": "Non-Small Cell Lung Cancer",
+            "oncotree_code": "NSCLC",
+            "therapy_name": "Entrectinib",
+            "therapy_strategy": "ROS1 inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval for entrectinib for adult patients with metastatic non-small cell lung cancer (NSCLC) whose tumors are ROS1-positive.",
+            "source_type": "FDA",
+            "citation": "Genentech, Inc. Rozlytrek (entrectinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2019/212726s000lbl.pdf. Revised August 2019. Accessed November 12, 2020.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2019/212726s000lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2019-08-01",
+            "last_updated": "2024-04-11",
+            "_deprecated": false,
+            "feature_display": "ROS1 Fusion"
+        },
+        {
+            "feature_type": "Rearrangement",
+            "gene1": "ROS1",
+            "gene2": "",
+            "rearrangement_type": "",
+            "locus": "",
+            "disease": "Non-Small Cell Lung Cancer",
+            "context": "Locally advanced or metastatic",
+            "oncotree_term": "Non-Small Cell Lung Cancer",
+            "oncotree_code": "NSCLC",
+            "therapy_name": "Repotrectinib",
+            "therapy_strategy": "ROS1 inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to repotrectinib for the treatment of patients with locally advanced or metastatic ROS1-positive non-small cell lung cancer (NSCLC).",
+            "source_type": "FDA",
+            "citation": "Bristol-Myers Squibb Company. Augtyro (repotrectinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218213s000lbl.pdf. Revised November 2023. Accessed December 5, 2023.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/218213s000lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2023-11-15",
+            "last_updated": "2024-04-11",
+            "_deprecated": false,
+            "feature_display": "ROS1"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "MRE11",
+            "chromosome": "",
+            "start_position": "",
+            "end_position": "",
+            "reference_allele": "",
+            "alternate_allele": "",
+            "cdna_change": "",
+            "protein_change": "",
+            "variant_annotation": "",
+            "exon": "",
+            "rsid": "",
+            "disease": "Prostate Cancer",
+            "context": "Metastatic castration-resistant",
+            "oncotree_term": "Prostate Adenocarcinoma",
+            "oncotree_code": "PRAD",
+            "therapy_name": "Enzalutamide + Talazoparib",
+            "therapy_strategy": "Antiandrogen + PARP inhibition",
+            "therapy_type": "Combination therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "adverse_event_risk": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to talazoparib in combination with enzalutamide for the treatment of adult patients with HRR gene-mutated metastatic castration-resistant prostate cancer (mCRPC).",
+            "source_type": "FDA",
+            "citation": "Pfizer, Inc. Talzenna (talazoparib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/211651s010lbl.pdf. Revised June 2023. Accessed July 6, 2023.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/211651s010lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2023-06-20",
+            "last_updated": "2024-04-11",
+            "_deprecated": false,
+            "feature_display": "MRE11"
+        },
+        {
+            "feature_type": "Rearrangement",
+            "gene1": "BCR",
+            "gene2": "ABL1",
+            "rearrangement_type": "Fusion",
+            "locus": "",
+            "disease": "Acute Lymphoblastic Leukemia",
+            "context": "",
+            "oncotree_term": "Acute Lymphoid Leukemia",
+            "oncotree_code": "ALL",
+            "therapy_name": "Ponatinib + Chemotherapy",
+            "therapy_strategy": "targets BCR-ABL + Chemotherapy",
+            "therapy_type": "Combination therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "adverse_event_risk": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to ponatinib in combination with chemotherapy for the treatment of adult patients with newly diagnosed Philadelphia chromosome-positive acute lymphoblastic leukemia. Ponatinib's package insert further states that this indication is approved under accelerated approval based on minimal residual disease (MRD)-negative complete transmission (CR) at the end of induction.",
+            "source_type": "FDA",
+            "citation": "Takeda Pharmaceuticals America, Inc. Iclusig (ponatinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/203469s037lbl.pdf. Revised March 2024. Accessed April 11, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/203469s037lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2024-03-19",
+            "last_updated": "2024-04-11",
+            "_deprecated": false,
+            "feature_display": "BCR--ABL1 Fusion"
+        },
+        {
+            "feature_type": "Rearrangement",
+            "gene1": "BCR",
+            "gene2": "ABL1",
+            "rearrangement_type": "Fusion",
+            "locus": "",
+            "disease": "Acute Lymphoblastic Leukemia",
+            "context": "",
+            "oncotree_term": "Acute Lymphoid Leukemia",
+            "oncotree_code": "ALL",
+            "therapy_name": "Ponatinib",
+            "therapy_strategy": "targets BCR-ABL",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "adverse_event_risk": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to ponatinib for the treatment of adult patients with Philadelphia chromosome-positive (Ph+) acute lymphoblastic leukemia (ALL) for whom no other kinase inhibitors are indicated.",
+            "source_type": "FDA",
+            "citation": "Takeda Pharmaceuticals America, Inc. Iclusig (ponatinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2013/203469s007s008lbl.pdf. Revised December 2013. Accessed April 11, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2013/203469s007s008lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2013-12-20",
+            "last_updated": "2024-04-11",
+            "_deprecated": false,
+            "feature_display": "BCR--ABL1 Fusion"
+        },
+        {
+            "feature_type": "Rearrangement",
+            "gene1": "BCR",
+            "gene2": "ABL1",
+            "rearrangement_type": "Fusion",
+            "locus": "",
+            "disease": "Acute Lymphoblastic Leukemia",
+            "context": "",
+            "oncotree_term": "Acute Lymphoid Leukemia",
+            "oncotree_code": "ALL",
+            "therapy_name": "Ponatinib",
+            "therapy_strategy": "targets BCR-ABL",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "adverse_event_risk": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to ponatinib for the treatment of adult patients with T315I-positive Philadelphia chromosome-positive (Ph+) acute lymphoblastic leukemia (ALL).",
+            "source_type": "FDA",
+            "citation": "Takeda Pharmaceuticals America, Inc. Iclusig (ponatinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2013/203469s007s008lbl.pdf. Revised December 2013. Accessed April 11, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2013/203469s007s008lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2013-12-20",
+            "last_updated": "2024-04-11",
+            "_deprecated": false,
+            "feature_display": "BCR--ABL1 Fusion"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "ABL1",
+            "chromosome": "9",
+            "start_position": 133748283,
+            "end_position": 133748283,
+            "reference_allele": "C",
+            "alternate_allele": "T",
+            "cdna_change": "c.944C>T",
+            "protein_change": "p.T315I",
+            "variant_annotation": "Missense",
+            "exon": 5,
+            "rsid": "rs121913459",
+            "disease": "Acute Lymphoblastic Leukemia",
+            "context": "",
+            "oncotree_term": "Acute Lymphoid Leukemia",
+            "oncotree_code": "ALL",
+            "therapy_name": "Ponatinib",
+            "therapy_strategy": "targets BCR-ABL",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "adverse_event_risk": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to ponatinib for the treatment of adult patients with T315I-positive Philadelphia chromosome-positive (Ph+) acute lymphoblastic leukemia (ALL).",
+            "source_type": "FDA",
+            "citation": "Takeda Pharmaceuticals America, Inc. Iclusig (ponatinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2013/203469s007s008lbl.pdf. Revised December 2013. Accessed April 11, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2013/203469s007s008lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2013-12-20",
+            "last_updated": "2024-04-11",
+            "_deprecated": false,
+            "feature_display": "ABL1 p.T315I (Missense)"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "ABL1",
+            "chromosome": "9",
+            "start_position": 133748283,
+            "end_position": 133748283,
+            "reference_allele": "C",
+            "alternate_allele": "T",
+            "cdna_change": "c.944C>T",
+            "protein_change": "p.T315I",
+            "variant_annotation": "Missense",
+            "exon": 5,
+            "rsid": "rs121913459",
+            "disease": "Chronic Myeloid Leukemia",
+            "context": "",
+            "oncotree_term": "Chronic Myelogenous Leukemia",
+            "oncotree_code": "CML",
+            "therapy_name": "Ponatinib",
+            "therapy_strategy": "targets BCR-ABL",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "adverse_event_risk": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted approval to ponatinib for the treatment of adult patients with T315I-positive chronic myeloid leukemia (CML) in the chronic phase, accelerated phase, or blast phase.",
+            "source_type": "FDA",
+            "citation": "Takeda Pharmaceuticals America, Inc. Iclusig (ponatinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2013/203469s007s008lbl.pdf. Revised December 2013. Accessed April 11, 2024.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2013/203469s007s008lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2013-12-20",
+            "last_updated": "2024-04-11",
+            "_deprecated": false,
+            "feature_display": "ABL1 p.T315I (Missense)"
         }
     ]
 }


### PR DESCRIPTION
This pull request updates the [molecular oncology almanac database](https://github.com/vanallenlab/moalmanac-db) used by this algorithm to the [2024-04-11 release](https://github.com/vanallenlab/moalmanac-db/releases/tag/v.2024-04-11).

Revisions:
- `moalmanac/datasources/moalmanac/create_almanac_db.py` was revised to (i) take the config.ini file as an input argument and (ii) skip a record if the `_deprecated` field is set to `False`. 

Pre-pull request check list,
- [x] Relevant documentation has been updated
- [x] All unit tests pass
- [x] All outputs pre- and post- changes match by md5 hash
- [x] All files changed have been reviewed