### PR TITLE
Shutdown logging

### DIFF
--- a/moalmanac/config.ini
+++ b/moalmanac/config.ini
@@ -13,14 +13,14 @@ include_preclinical_efficacy_in_actionability_report = on
 level = INFO
 
 [versions]
-interpreter = 0.7.3
+interpreter = 0.7.4
 database = v.2024-10-03
 
 [exac]
 exac_common_af_threshold = 0.001
 
 [fusion]
-spanningfrags_min = 5.0
+spanningfrags_min = 5
 alt_type = Fusion
 leftbreakpoint = leftbreakpoint
 rightbreakpoint = rightbreakpoint

--- a/moalmanac/logger.py
+++ b/moalmanac/logger.py
@@ -10,12 +10,19 @@ class Logger:
     @classmethod
     def setup(cls, output_folder, file_prefix, config):
         filename = cls.generate_filename(folder=output_folder, label=file_prefix)
+        logger = logging.getLogger()
+        if logger.hasHandlers():
+            logger.handlers.clear()
         logging.basicConfig(
             filename=filename,
             filemode='w',
             format="%(asctime)s - %(levelname)s - %(message)s",
             level=config['logging']['level']
         )
+
+    @classmethod
+    def shutdown(cls):
+        logging.shutdown()
 
 
 class Messages:

--- a/moalmanac/moalmanac.py
+++ b/moalmanac/moalmanac.py
@@ -715,6 +715,7 @@ def main(patient, inputs, output_folder, config, dbs, dbs_preclinical=None):
     end_time = time.time()
     elapsed_time = round((end_time - start_time), 4)
     logger.Messages.general("Molecular Oncology Almanac process complete. Runtime: %s seconds" % elapsed_time)
+    logger.Logger.shutdown()
 
 
 if __name__ == "__main__":

--- a/moalmanac/run_4x_for_output_regression_test.py
+++ b/moalmanac/run_4x_for_output_regression_test.py
@@ -1,0 +1,178 @@
+import moalmanac
+import os
+import subprocess
+import time
+
+from datetime import date
+
+from reader import Ini
+
+pre_or_post_code_changes = "pre"
+#pre_or_post_code_changes = "post"
+
+metadata_dictionary = {
+    'patient_id': 'example',
+    'reported_tumor_type': 'MEL',
+    'stage': 'Metastatic',
+    'description': 'Test patient for development runs',
+    'purity': 0.85,
+    'ploidy': 4.02,
+    'WGD': True,
+    'microsatellite_status': 'msih'
+}
+
+input_dictionary_empty = {
+    'snv_handle': '',
+    'indel_handle': '',
+    'bases_covered_handle': '',
+    'called_cn_handle': '',
+    'cnv_handle': '',
+    'fusion_handle': '',
+    'germline_handle': '',
+    'validation_handle': '',
+    'mutational_signatures_path': '',
+    'disable_matchmaking': False
+}
+
+input_dictionary = {
+    'snv_handle': '../example_data/example_patient.capture.somatic.snvs.maf',
+    'indel_handle': '../example_data/example_patient.capture.somatic.indels.maf',
+    'bases_covered_handle': '../example_data/example_patient.capture.somatic.coverage.txt',
+    'called_cn_handle': '../example_data/example_patient.capture.somatic.called.cna.txt',
+    'cnv_handle': '../example_data/example_patient.capture.somatic.seg.annotated',
+    'fusion_handle': '../example_data/example_patient.rna.star.fusions.txt',
+    'germline_handle': '../example_data/example_patient.capture.germline.maf',
+    'validation_handle': '../example_data/example_patient.rna.somatic.snvs.maf',
+    'mutational_signatures_path': '../example_data/example_patient.capture.sbs_contributions.txt',
+    'disable_matchmaking': False
+}
+
+config_ini_path = "config.ini"
+config_ini = Ini.read(config_ini_path, extended_interpolation=False, convert_to_dictionary=False)
+
+dbs_ini_path = "annotation-databases.ini"
+db_paths = Ini.read(dbs_ini_path, extended_interpolation=True, convert_to_dictionary=True)
+db_paths = db_paths['paths']
+
+dbs_preclinical_ini_path = "preclinical-databases.ini"
+preclinical_db_paths = Ini.read(dbs_preclinical_ini_path, extended_interpolation=True, convert_to_dictionary=True)
+preclinical_db_paths = preclinical_db_paths['paths']
+
+
+def execute_cmd(command):
+    subprocess.call(command, shell=True)
+
+
+today = date.today().isoformat()
+
+"""
+First execution, all example inputs with all settings within the function toggle enabled
+"""
+for key, value in config_ini.items('function_toggle'):
+    config_ini['function_toggle'][key] = 'on'
+
+output_directory = f"{today}-example-outputs-full-all-enabled-{pre_or_post_code_changes}"
+if output_directory != "":
+    cmd = f"mkdir -p {output_directory}"
+    execute_cmd(cmd)
+else:
+    output_directory = os.getcwd()
+
+start_time = time.time()
+
+moalmanac.main(
+    patient=metadata_dictionary,
+    inputs=input_dictionary,
+    output_folder=output_directory,
+    config=config_ini,
+    dbs=db_paths,
+    dbs_preclinical=preclinical_db_paths
+)
+
+end_time = time.time()
+
+time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round((end_time - start_time), 4)
+print(time_statement)
+
+"""
+Second execution, all empty example inputs with all settings within the function toggle enabled
+"""
+for key, value in config_ini.items('function_toggle'):
+    config_ini['function_toggle'][key] = 'on'
+
+output_directory = f"{today}-example-outputs-empty-all-enabled-{pre_or_post_code_changes}"
+if output_directory != "":
+    cmd = f"mkdir -p {output_directory}"
+    execute_cmd(cmd)
+else:
+    output_directory = os.getcwd()
+
+start_time = time.time()
+moalmanac.main(
+    patient=metadata_dictionary,
+    inputs=input_dictionary_empty,
+    output_folder=output_directory,
+    config=config_ini,
+    dbs=db_paths,
+    dbs_preclinical=preclinical_db_paths
+)
+end_time = time.time()
+
+time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round((end_time - start_time), 4)
+print(time_statement)
+
+"""
+Third execution, all example inputs with all settings within the function toggle disabled
+"""
+for key, value in config_ini.items('function_toggle'):
+    config_ini['function_toggle'][key] = 'off'
+
+output_directory = f"{today}-example-outputs-full-all-disabled-{pre_or_post_code_changes}"
+if output_directory != "":
+    cmd = f"mkdir -p {output_directory}"
+    execute_cmd(cmd)
+else:
+    output_directory = os.getcwd()
+
+start_time = time.time()
+
+moalmanac.main(
+    patient=metadata_dictionary,
+    inputs=input_dictionary,
+    output_folder=output_directory,
+    config=config_ini,
+    dbs=db_paths,
+    dbs_preclinical=preclinical_db_paths
+)
+
+end_time = time.time()
+
+time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round((end_time - start_time), 4)
+print(time_statement)
+
+"""
+Fourth execution, all empty example inputs with all settings within the function toggle disabled
+"""
+for key, value in config_ini.items('function_toggle'):
+    config_ini['function_toggle'][key] = 'off'
+
+output_directory = f"{today}-example-outputs-empty-all-disabled-{pre_or_post_code_changes}"
+if output_directory != "":
+    cmd = f"mkdir -p {output_directory}"
+    execute_cmd(cmd)
+else:
+    output_directory = os.getcwd()
+
+start_time = time.time()
+moalmanac.main(
+    patient=metadata_dictionary,
+    inputs=input_dictionary_empty,
+    output_folder=output_directory,
+    config=config_ini,
+    dbs=db_paths,
+    dbs_preclinical=preclinical_db_paths
+)
+end_time = time.time()
+
+time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round((end_time - start_time), 4)
+print(time_statement)


### PR DESCRIPTION
This pull request updates the interpreter to version 0.7.4. We added a new script to run regression tests, `run_4x_for_output_regression_test.py`, that will run the interpreter 4 times based on passing and not passing inputs and different configuration settings. 

We also discovered that the logger was writing to the same log when multiple instantiations of the main function were called within the same Python process. So, we revised `moalmanac/logger.py` to create a separate log for each call of the main function, which is the intended behavior.

Additions:
- An added function to `moalmanac/logger.py` to shutdown the logger, and added this to the main function of `moalmanac/moalmanac.py`.
- A new script `run_4x_for_output_regression_test.py` to run the run_example.py four times: 
    - with toggle-able settings from the `function_toggle` section of `moalmanac/config.in` enabled, and example genomic data from `example_data/`
    - with toggle-able settings from the `function_toggle` section of `moalmanac/config.in` enabled, and no input genomic data
    - with toggle-able settings from the `function_toggle` section of `moalmanac/config.in` disabled, and example genomic data from `example_data/`
    - with toggle-able settings from the `function_toggle` section of `moalmanac/config.in` disabled, and no input genomic data

Revisions:
- Removed existing handlers for logging within the `setup` function of `moalmanac/logger.py`. This allows separate logs to be created if the main function is being called in series within a single python process. 

Pre-pull request check list,
- [x] Relevant documentation has been updated
- [x] All unit tests pass
- [x] All outputs pre- and post- changes match by md5 hash
- [x] All files changed have been reviewed
- [x] Docker pushed
