### PR TITLE
Updated docker build to support multiple architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The codebase is available for download through this GitHub repository, [Dockerhu
 ### Installation
 Molecular Oncology Almanac is a Python application using Python 3.12. This application, datasources, and all dependencies are packaged on Docker and can be downloaded with the command
  ```bash
-docker pull vanallenlab/moalmanac
+docker pull vanallenlab/moalmanac:latest
 ```
 
 Alternatively, the package can be built from this GitHub repository. To download via GitHub,

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -6,11 +6,8 @@ sed -i "" -e "s#colnames.ini#/moalmanac/colnames.ini#" moalmanac/config.py
 sed -i "" -e "s#../datasources#/datasources#" moalmanac/annotation-databases.ini
 sed -i "" -e "s#../datasources#/datasources#" moalmanac/preclinical-databases.ini
 
-docker build -t vanallenlab/moalmanac:"${tag}" .
-docker push vanallenlab/moalmanac:"${tag}"
-
-docker build -t vanallenlab/moalmanac:latest .
-docker push vanallenlab/moalmanac:latest
+docker buildx build --platform linux/amd64,linux/arm64/v8 -t vanallenlab/moalmanac:"${tag}" --push .
+docker buildx build --platform linux/amd64,linux/arm64/v8 -t vanallenlab/moalmanac:latest --push .
 
 sed -i "" -e "s#/moalmanac/colnames.ini#colnames.ini#" moalmanac/config.py
 sed -i "" -e "s#/datasources#../datasources#" moalmanac/annotation-databases.ini


### PR DESCRIPTION
`build_docker.sh` was updated to support multiple architectures. Specifically, we change the bash script to use docker's [buildx](https://docs.docker.com/reference/cli/docker/buildx/) to build for both linux/amd64 and linux/arm64/v8, which should support most users. 

Revisions:
- Within `build_docker.sh`, replaced `docker build -t....` with `docker buildx build --platform linux/amd64,linux/arm64/v8 -t...`
- Changed `docker pull vanallenlab/moalmanac` to `docker pull vanallenlab/moalmanac:latest` under the **Installation** section of the root directory README.

No underlying code for either the datasources or method was updated with this pull request. Pushed the new container to [vanallenlab/moalmanac:0.8.1.1_v.2024-12-05](https://hub.docker.com/repository/docker/vanallenlab/moalmanac/tags/0.8.1.1_v.2024-12-05/sha256-ee7d9555d72f02869ad86e6b250122f194a4c2d8052c3bed7ad6b086926f3cfd).

Thank you to @sabrinacamp2 for this recommendation 🙇 

Pre-pull request check list,
- [x] Relevant documentation has been updated
- [ ] All unit tests pass
- [ ] All outputs pre- and post- changes match by md5 hash
- [ ] All files changed have been reviewed
- [x] Docker pushed
