### PR TITLE
Revisions to datasource documentation

### DIFF
--- a/datasources/clinvar/README.md
+++ b/datasources/clinvar/README.md
@@ -2,7 +2,7 @@
 Molecular Oncology Almanac utilizes [ClinVar](https://www.ncbi.nlm.nih.gov/clinvar/) to annotate the clinical significance of germline variants. Germline alterations which are annotated as benign will not be reported in the actionable output from Molecular Oncology Almanac, but will still be reported in all other outputs. 
 
 ## About ClinVar
-ClinVar is a freely accessible database which reports relationships between human genetic variation and phenotypes. It is hosted by the National Center for Biotechnology Information (NCBI) and funded by the National Institutes of Health (NIH). ClinVar has recently partnered with the [Clinical Geome Resource](https://www.clinicalgenome.org/).
+ClinVar is a freely accessible database which reports relationships between human genetic variation and phenotypes. It is hosted by the National Center for Biotechnology Information (NCBI) and funded by the National Institutes of Health (NIH). ClinVar has recently partnered with the [Clinical Genome Resource](https://www.clinicalgenome.org/).
 
 ## Usage: Downloading ClinVar for use
 Releases of ClinVar [are available for download from their FTP server](ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar) and, as of this writing, Molecular Oncology Almanac utilizes [variant_summary.txt.gz](ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/), accessed on October 25th, 2018. 

--- a/datasources/exac/README.md
+++ b/datasources/exac/README.md
@@ -1,5 +1,5 @@
 # Databases: Exome Aggregation Consortium (ExAC)
-The Molecular Oncology Almanac utilizes [ExAC](http://exac.broadinstitute.org/) to annotate population allele frequency of alterations and identify variants that may not be related to cancer. Specifically, our heuristic will sort against alterations that appear in ExAC. While alterations will stay in their same bin,they will appear lower than other variants that do not appear in ExAC.
+The Molecular Oncology Almanac utilizes [ExAC](http://exac.broadinstitute.org/) to annotate population allele frequency of alterations and identify variants that may not be related to cancer. Specifically, our heuristic will sort against alterations that appear in ExAC. While alterations will stay in their same bin, they will appear lower than other variants that do not appear in ExAC.
 
 ## About the Exome Aggregation Consortium
 The Exome Aggregation Consortium was developed and is maintained by [several principle investigators](http://exac.broadinstitute.org/about). It is a dataset of germline sequencing data from over 60,000 unrelated individuals. 

--- a/datasources/oncotree/README.md
+++ b/datasources/oncotree/README.md
@@ -2,7 +2,7 @@
 The Molecular Oncology Almanac utilizes OncoTree to standardize the input of disease ontology in order to frame a given patient's mutational burden and match assertions from the almanac as closely as possible. 
 
 ## About Oncotree
-OncoTree was developed by Memorial Sloan Kettering Cancer Center as a tool for the cBioPortal and distributed under a Creative Commons Attribution 4.0 International License. Please visit their [website][1], [swagger][2], or [GitHub][3] to learn more.
+OncoTree was developed by Memorial Sloan Kettering Cancer Center as a tool for the cBioPortal and distributed under a Creative Commons Attribution 4.0 International License. Please visit their [website](https://oncotree.mskcc.org/), [API](https://oncotree.mskcc.org/swagger-ui.html), or [GitHub](https://github.com/cBioPortal/oncotree) to learn more.
 
 ## Usage: Generating OncoTree for use
 The following command can be run to generate a new OncoTree table for usage with the Molecular Oncology Almanac.

--- a/datasources/preclinical/annotated/README.md
+++ b/datasources/preclinical/annotated/README.md
@@ -1,5 +1,5 @@
 # Annotated inputs
-Molecular features formatted as described in the `formatted/` folder are to be annotated by [MOAlmanac](https://github.com/vanallenlab/moalmanac) before use. Inputs requirements are needed to run this step are,
+Molecular features formatted as described in the `formatted/` folder are to be annotated by [MOAlmanac](https://github.com/vanallenlab/moalmanac) before use. The inputs requirements are needed to run this step are,
 - A formatted input for somatic variants, as described in the `formatted/` folder
 - A formatted input for copy number alterations, as described in the `formatted/` folder
 - A formatted input for fusions, as described in the `formatted/` folder

--- a/moalmanac/README.md
+++ b/moalmanac/README.md
@@ -13,7 +13,7 @@ Required arguments:
 
 Optional arguments:
 ```
-    --tumor_type            <string>    tumor ontology, default=Unknown
+    --tumor_type            <string>    tumor ontology, default=Unknown, MOAlmanac will attempt to map to both OncoTree codes and terms.
     --stage                 <string>    tumor stage, default=Unknown
     --snv_handle            <string>    handle for MAF file of somatic single nucleotide variants
     --indel_handle          <string>    handle for MAF file of somatic insertions and deletions

--- a/moalmanac/moalmanac.py
+++ b/moalmanac/moalmanac.py
@@ -761,7 +761,7 @@ if __name__ == "__main__":
     arg_parser.add_argument(
         '--tumor_type',
         default='Unknown',
-        help='reported tumor type'
+        help='reported tumor type, will attempt to map to both OncoTree codes and terms.'
     )
     arg_parser.add_argument(
         '--stage',


### PR DESCRIPTION
This pull request incorporates minor changes to documentation throughout the repository, based on recommendations from @sabrinacamp2, Jen Altreuter from Dana-Farber Cancer Institute, and Kaelyn Nannini from Veteran Affairs.

OncoTree changes were [originally directly committed to the main branch](https://github.com/vanallenlab/moalmanac/commit/96912575a17be7e0df4452ff036690d2fd457684) and were reverted to incorporate via this pull request. The main branch is now protected against direct commits. 

Revisions:
- Hyperlinks within `datasources/oncotree/README.md` were correctly referenced.
- We now specify within `moalmanac/README.md` and `moalmanac/moalmanac.py` that the code will attempt to map the `--tumor_type` argument to OncoTree codes and terms. 
- Editorial changes to `datasources/clinvar/README.md`, `datasources/exac/README.md`, and `datasources/preclinical/annotated/README.md`. 

Because this pull request only impacts documentation, we will not create a release or push a new Docker image.

Pre-pull request check list,
- [x] Relevant documentation has been updated
- [ ] All unit tests pass
- [ ] All outputs pre- and post- changes match by md5 hash
- [ ] All files changed have been reviewed
- [ ] Docker pushed
