### PR TITLE
Update moalmanac db to 2025-02-07 release

### DIFF
--- a/datasources/moalmanac/create_almanac_db.py
+++ b/datasources/moalmanac/create_almanac_db.py
@@ -260,7 +260,7 @@ if __name__ == "__main__":
         '--config',
         '-c',
         help='MOAlmanac configuration file',
-        default='../../config.ini'
+        default='../../moalmanac/config.ini'
     )
     arg_parser.add_argument(
         '--file',

--- a/datasources/moalmanac/molecular-oncology-almanac.json
+++ b/datasources/moalmanac/molecular-oncology-almanac.json
@@ -1,5 +1,5 @@
 {
-    "release": "2024-12-05",
+    "release": "2025-02-07",
     "version": "1.3.0",
     "genes": [
         "ABL1",
@@ -184,6 +184,9 @@
             "publication_date": "2021-05-01",
             "last_updated": "2021-09-16",
             "_deprecated": false,
+            "assertion_id": 1,
+            "feature_id": 1,
+            "source_id": 1,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -213,6 +216,9 @@
             "publication_date": "2018-12-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 2,
+            "feature_id": 2,
+            "source_id": 2,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -242,6 +248,9 @@
             "publication_date": "2018-12-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 3,
+            "feature_id": 3,
+            "source_id": 2,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -271,6 +280,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 4,
+            "feature_id": 4,
+            "source_id": 3,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -300,6 +312,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 5,
+            "feature_id": 5,
+            "source_id": 3,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -329,6 +344,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 6,
+            "feature_id": 6,
+            "source_id": 4,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -358,6 +376,9 @@
             "publication_date": "2010-06-17",
             "last_updated": "2019-08-14",
             "_deprecated": false,
+            "assertion_id": 7,
+            "feature_id": 7,
+            "source_id": 5,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -387,6 +408,9 @@
             "publication_date": "2024-10-29",
             "last_updated": "2024-11-06",
             "_deprecated": false,
+            "assertion_id": 8,
+            "feature_id": 8,
+            "source_id": 6,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -416,6 +440,9 @@
             "publication_date": "2018-06-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 9,
+            "feature_id": 9,
+            "source_id": 7,
             "feature_display": "ALK Fusion"
         },
         {
@@ -445,6 +472,9 @@
             "publication_date": "2011-08-26",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 10,
+            "feature_id": 10,
+            "source_id": 8,
             "feature_display": "ALK Fusion"
         },
         {
@@ -474,6 +504,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 11,
+            "feature_id": 11,
+            "source_id": 9,
             "feature_display": "ALK Fusion"
         },
         {
@@ -503,6 +536,9 @@
             "publication_date": "2019-03-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 12,
+            "feature_id": 12,
+            "source_id": 10,
             "feature_display": "ALK"
         },
         {
@@ -532,6 +568,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 13,
+            "feature_id": 13,
+            "source_id": 11,
             "feature_display": "ALK Fusion"
         },
         {
@@ -561,6 +600,9 @@
             "publication_date": "2014-03-27",
             "last_updated": "2019-08-10",
             "_deprecated": false,
+            "assertion_id": 14,
+            "feature_id": 14,
+            "source_id": 12,
             "feature_display": "ALK"
         },
         {
@@ -590,6 +632,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 15,
+            "feature_id": 15,
+            "source_id": 13,
             "feature_display": "ALK Translocation"
         },
         {
@@ -619,6 +664,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 16,
+            "feature_id": 16,
+            "source_id": 13,
             "feature_display": "ALK Translocation"
         },
         {
@@ -648,6 +696,9 @@
             "publication_date": "2010-10-28",
             "last_updated": "2019-08-10",
             "_deprecated": false,
+            "assertion_id": 17,
+            "feature_id": 17,
+            "source_id": 14,
             "feature_display": "ALK Translocation"
         },
         {
@@ -677,6 +728,9 @@
             "publication_date": "2010-09-24",
             "last_updated": "2018-09-14",
             "_deprecated": false,
+            "assertion_id": 18,
+            "feature_id": 18,
+            "source_id": 15,
             "feature_display": "BRD4 Translocation"
         },
         {
@@ -706,6 +760,9 @@
             "publication_date": "2016-08-17",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 19,
+            "feature_id": 19,
+            "source_id": 16,
             "feature_display": "CCND1 Translocation"
         },
         {
@@ -735,6 +792,9 @@
             "publication_date": "2013-03-17",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 20,
+            "feature_id": 20,
+            "source_id": 17,
             "feature_display": "CCND1 Translocation"
         },
         {
@@ -764,6 +824,9 @@
             "publication_date": "2016-08-17",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 21,
+            "feature_id": 21,
+            "source_id": 16,
             "feature_display": "CCND3 Translocation"
         },
         {
@@ -793,6 +856,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 22,
+            "feature_id": 22,
+            "source_id": 18,
             "feature_display": "COL1A1--PDGFB Fusion"
         },
         {
@@ -822,6 +888,9 @@
             "publication_date": "2023-10-01",
             "last_updated": "2019-08-09",
             "_deprecated": false,
+            "assertion_id": 23,
+            "feature_id": 23,
+            "source_id": 19,
             "feature_display": "EML4--ALK Fusion"
         },
         {
@@ -851,6 +920,9 @@
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 24,
+            "feature_id": 24,
+            "source_id": 20,
             "feature_display": "EML4--ALK Fusion"
         },
         {
@@ -880,6 +952,9 @@
             "publication_date": "2010-06-06",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 25,
+            "feature_id": 25,
+            "source_id": 21,
             "feature_display": "ESRP1--RAF1 Fusion"
         },
         {
@@ -909,6 +984,9 @@
             "publication_date": "2010-06-06",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 26,
+            "feature_id": 26,
+            "source_id": 21,
             "feature_display": "ESRP1--RAF1 Fusion"
         },
         {
@@ -938,6 +1016,9 @@
             "publication_date": "2017-01-01",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 27,
+            "feature_id": 27,
+            "source_id": 22,
             "feature_display": "EWSR1--FLI1 Fusion"
         },
         {
@@ -967,6 +1048,9 @@
             "publication_date": "2014-02-13",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 28,
+            "feature_id": 28,
+            "source_id": 23,
             "feature_display": "FGFR2--TACC3 Fusion"
         },
         {
@@ -996,6 +1080,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 29,
+            "feature_id": 29,
+            "source_id": 24,
             "feature_display": "FGFR2 Fusion"
         },
         {
@@ -1025,6 +1112,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 30,
+            "feature_id": 30,
+            "source_id": 24,
             "feature_display": "FGFR2"
         },
         {
@@ -1054,6 +1144,9 @@
             "publication_date": "2021-05-01",
             "last_updated": "2021-06-01",
             "_deprecated": false,
+            "assertion_id": 31,
+            "feature_id": 31,
+            "source_id": 25,
             "feature_display": "FGFR2 Fusion"
         },
         {
@@ -1083,6 +1176,9 @@
             "publication_date": "2024-01-19",
             "last_updated": "2024-01-25",
             "_deprecated": false,
+            "assertion_id": 32,
+            "feature_id": 32,
+            "source_id": 26,
             "feature_display": "FGFR3 Fusion"
         },
         {
@@ -1112,6 +1208,9 @@
             "publication_date": "2013-05-16",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 33,
+            "feature_id": 33,
+            "source_id": 27,
             "feature_display": "FGFR3--NSD2 Fusion"
         },
         {
@@ -1141,6 +1240,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 34,
+            "feature_id": 34,
+            "source_id": 28,
             "feature_display": "IGH Translocation"
         },
         {
@@ -1170,6 +1272,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 35,
+            "feature_id": 35,
+            "source_id": 28,
             "feature_display": "IGH Translocation"
         },
         {
@@ -1199,6 +1304,9 @@
             "publication_date": "2018-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 36,
+            "feature_id": 36,
+            "source_id": 29,
             "feature_display": "NTRK1 Fusion"
         },
         {
@@ -1228,6 +1336,9 @@
             "publication_date": "2016-03-18",
             "last_updated": "2017-03-16",
             "_deprecated": false,
+            "assertion_id": 37,
+            "feature_id": 37,
+            "source_id": 30,
             "feature_display": "NTRK1 Fusion"
         },
         {
@@ -1257,6 +1368,9 @@
             "publication_date": "2023-10-20",
             "last_updated": "2023-11-01",
             "_deprecated": false,
+            "assertion_id": 38,
+            "feature_id": 38,
+            "source_id": 31,
             "feature_display": "NTRK1 Fusion"
         },
         {
@@ -1286,6 +1400,9 @@
             "publication_date": "2018-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 39,
+            "feature_id": 39,
+            "source_id": 29,
             "feature_display": "NTRK2 Fusion"
         },
         {
@@ -1315,6 +1432,9 @@
             "publication_date": "2016-03-18",
             "last_updated": "2017-03-16",
             "_deprecated": false,
+            "assertion_id": 40,
+            "feature_id": 40,
+            "source_id": 30,
             "feature_display": "NTRK2 Fusion"
         },
         {
@@ -1344,6 +1464,9 @@
             "publication_date": "2023-10-20",
             "last_updated": "2023-11-01",
             "_deprecated": false,
+            "assertion_id": 41,
+            "feature_id": 41,
+            "source_id": 31,
             "feature_display": "NTRK2 Fusion"
         },
         {
@@ -1373,6 +1496,9 @@
             "publication_date": "2018-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 42,
+            "feature_id": 42,
+            "source_id": 29,
             "feature_display": "NTRK3 Fusion"
         },
         {
@@ -1402,6 +1528,9 @@
             "publication_date": "2016-03-18",
             "last_updated": "2017-03-16",
             "_deprecated": false,
+            "assertion_id": 43,
+            "feature_id": 43,
+            "source_id": 30,
             "feature_display": "NTRK3 Fusion"
         },
         {
@@ -1431,6 +1560,9 @@
             "publication_date": "2023-10-20",
             "last_updated": "2023-11-01",
             "_deprecated": false,
+            "assertion_id": 44,
+            "feature_id": 44,
+            "source_id": 31,
             "feature_display": "NTRK3 Fusion"
         },
         {
@@ -1460,6 +1592,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 45,
+            "feature_id": 45,
+            "source_id": 3,
             "feature_display": "PDGFRA"
         },
         {
@@ -1489,6 +1624,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 46,
+            "feature_id": 46,
+            "source_id": 3,
             "feature_display": "FIP1L1--PDGFRA Fusion"
         },
         {
@@ -1518,6 +1656,9 @@
             "publication_date": "2003-08-23",
             "last_updated": "2019-03-19",
             "_deprecated": false,
+            "assertion_id": 47,
+            "feature_id": 47,
+            "source_id": 32,
             "feature_display": "BCR--PDGFRA Fusion"
         },
         {
@@ -1547,6 +1688,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 48,
+            "feature_id": 48,
+            "source_id": 3,
             "feature_display": "PDGFRB"
         },
         {
@@ -1576,6 +1720,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 49,
+            "feature_id": 49,
+            "source_id": 33,
             "feature_display": "ETV6--PDGFRB Fusion"
         },
         {
@@ -1605,6 +1752,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 50,
+            "feature_id": 50,
+            "source_id": 11,
             "feature_display": "RET"
         },
         {
@@ -1634,6 +1784,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 51,
+            "feature_id": 51,
+            "source_id": 11,
             "feature_display": "RET"
         },
         {
@@ -1663,6 +1816,9 @@
             "publication_date": "2013-06-06",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 52,
+            "feature_id": 52,
+            "source_id": 34,
             "feature_display": "RET Fusion"
         },
         {
@@ -1692,6 +1848,9 @@
             "publication_date": "2020-05-08",
             "last_updated": "2024-06-03",
             "_deprecated": false,
+            "assertion_id": 53,
+            "feature_id": 53,
+            "source_id": 35,
             "feature_display": "RET Fusion"
         },
         {
@@ -1721,6 +1880,9 @@
             "publication_date": "2024-06-12",
             "last_updated": "2024-07-11",
             "_deprecated": false,
+            "assertion_id": 54,
+            "feature_id": 54,
+            "source_id": 36,
             "feature_display": "RET Fusion"
         },
         {
@@ -1750,6 +1912,9 @@
             "publication_date": "2023-08-09",
             "last_updated": "2023-09-06",
             "_deprecated": false,
+            "assertion_id": 55,
+            "feature_id": 55,
+            "source_id": 37,
             "feature_display": "RET Fusion"
         },
         {
@@ -1779,6 +1944,9 @@
             "publication_date": "2020-12-01",
             "last_updated": "2020-12-03",
             "_deprecated": false,
+            "assertion_id": 56,
+            "feature_id": 56,
+            "source_id": 38,
             "feature_display": "RET Fusion"
         },
         {
@@ -1808,6 +1976,9 @@
             "publication_date": "2016-03-11",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 57,
+            "feature_id": 57,
+            "source_id": 39,
             "feature_display": "ROS1 Fusion"
         },
         {
@@ -1836,7 +2007,10 @@
             "nct": "",
             "publication_date": "2019-08-01",
             "last_updated": "2020-11-12",
-            "_deprecated": true
+            "_deprecated": true,
+            "assertion_id": 58,
+            "feature_id": 58,
+            "source_id": 40
         },
         {
             "feature_type": "Rearrangement",
@@ -1865,6 +2039,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 59,
+            "feature_id": 59,
+            "source_id": 41,
             "feature_display": "RUNX1--RUNX1T1 Fusion"
         },
         {
@@ -1894,6 +2071,9 @@
             "publication_date": "2010-06-06",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 60,
+            "feature_id": 60,
+            "source_id": 21,
             "feature_display": "SLC45A3--BRAF Fusion"
         },
         {
@@ -1923,6 +2103,9 @@
             "publication_date": "2010-06-06",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 61,
+            "feature_id": 61,
+            "source_id": 21,
             "feature_display": "SLC45A3--BRAF Fusion"
         },
         {
@@ -1952,6 +2135,9 @@
             "publication_date": "2013-04-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 62,
+            "feature_id": 62,
+            "source_id": 42,
             "feature_display": "TMPRSS2--ERG Fusion"
         },
         {
@@ -1981,6 +2167,9 @@
             "publication_date": "2007-01-22",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 63,
+            "feature_id": 63,
+            "source_id": 43,
             "feature_display": "TMPRSS2--ERG Fusion"
         },
         {
@@ -2010,6 +2199,9 @@
             "publication_date": "2017-12-20",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 64,
+            "feature_id": 64,
+            "source_id": 44,
             "feature_display": "TMPRSS2--ERG Fusion"
         },
         {
@@ -2039,6 +2231,9 @@
             "publication_date": "2017-12-20",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 65,
+            "feature_id": 65,
+            "source_id": 44,
             "feature_display": "TMPRSS2--ERG Fusion"
         },
         {
@@ -2075,6 +2270,9 @@
             "publication_date": "2001-06-21",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 66,
+            "feature_id": 66,
+            "source_id": 45,
             "feature_display": "ABL1 p.T315I (Missense)"
         },
         {
@@ -2111,6 +2309,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 67,
+            "feature_id": 67,
+            "source_id": 46,
             "feature_display": "ABL1 (Missense)"
         },
         {
@@ -2147,6 +2348,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 68,
+            "feature_id": 68,
+            "source_id": 46,
             "feature_display": "ABL1 p.T315A (Missense)"
         },
         {
@@ -2183,6 +2387,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 69,
+            "feature_id": 69,
+            "source_id": 46,
             "feature_display": "ABL1 p.T315I (Missense)"
         },
         {
@@ -2219,6 +2426,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 70,
+            "feature_id": 70,
+            "source_id": 46,
             "feature_display": "ABL1 p.F317L (Missense)"
         },
         {
@@ -2255,6 +2465,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 71,
+            "feature_id": 71,
+            "source_id": 46,
             "feature_display": "ABL1 p.F317V (Missense)"
         },
         {
@@ -2291,6 +2504,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 72,
+            "feature_id": 72,
+            "source_id": 46,
             "feature_display": "ABL1 p.F317I (Missense)"
         },
         {
@@ -2327,6 +2543,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 73,
+            "feature_id": 73,
+            "source_id": 46,
             "feature_display": "ABL1 p.F317C (Missense)"
         },
         {
@@ -2363,6 +2582,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 74,
+            "feature_id": 74,
+            "source_id": 46,
             "feature_display": "ABL1"
         },
         {
@@ -2399,6 +2621,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 75,
+            "feature_id": 75,
+            "source_id": 46,
             "feature_display": "ABL1 p.E255K (Missense)"
         },
         {
@@ -2435,6 +2660,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 76,
+            "feature_id": 76,
+            "source_id": 46,
             "feature_display": "ABL1 p.E255V (Missense)"
         },
         {
@@ -2471,6 +2699,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 77,
+            "feature_id": 77,
+            "source_id": 46,
             "feature_display": "ABL1 p.Y253H (Missense)"
         },
         {
@@ -2507,6 +2738,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 78,
+            "feature_id": 78,
+            "source_id": 46,
             "feature_display": "ABL1 p.F359V (Missense)"
         },
         {
@@ -2543,6 +2777,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 79,
+            "feature_id": 79,
+            "source_id": 46,
             "feature_display": "ABL1 p.F359C (Missense)"
         },
         {
@@ -2579,6 +2816,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 80,
+            "feature_id": 80,
+            "source_id": 46,
             "feature_display": "ABL1 p.F359I (Missense)"
         },
         {
@@ -2615,6 +2855,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 81,
+            "feature_id": 81,
+            "source_id": 47,
             "feature_display": "ABL1 p.Y253H (Missense)"
         },
         {
@@ -2651,6 +2894,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 82,
+            "feature_id": 82,
+            "source_id": 47,
             "feature_display": "ABL1 p.E255K (Missense)"
         },
         {
@@ -2687,6 +2933,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 83,
+            "feature_id": 83,
+            "source_id": 47,
             "feature_display": "ABL1 p.E255V (Missense)"
         },
         {
@@ -2723,6 +2972,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 84,
+            "feature_id": 84,
+            "source_id": 47,
             "feature_display": "ABL1 p.F359V (Missense)"
         },
         {
@@ -2759,6 +3011,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 85,
+            "feature_id": 85,
+            "source_id": 47,
             "feature_display": "ABL1 p.F359C (Missense)"
         },
         {
@@ -2795,6 +3050,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 86,
+            "feature_id": 86,
+            "source_id": 47,
             "feature_display": "ABL1 p.F359I (Missense)"
         },
         {
@@ -2831,6 +3089,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 87,
+            "feature_id": 87,
+            "source_id": 47,
             "feature_display": "ABL1 p.F317L (Missense)"
         },
         {
@@ -2867,6 +3128,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 88,
+            "feature_id": 88,
+            "source_id": 47,
             "feature_display": "ABL1 p.F317V (Missense)"
         },
         {
@@ -2903,6 +3167,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 89,
+            "feature_id": 89,
+            "source_id": 47,
             "feature_display": "ABL1 p.F317I (Missense)"
         },
         {
@@ -2939,6 +3206,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 90,
+            "feature_id": 90,
+            "source_id": 47,
             "feature_display": "ABL1 p.F317C (Missense)"
         },
         {
@@ -2975,6 +3245,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 91,
+            "feature_id": 91,
+            "source_id": 47,
             "feature_display": "ABL1 p.T315A (Missense)"
         },
         {
@@ -3011,6 +3284,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 92,
+            "feature_id": 92,
+            "source_id": 47,
             "feature_display": "ABL1 p.V299L (Missense)"
         },
         {
@@ -3047,6 +3323,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 93,
+            "feature_id": 93,
+            "source_id": 47,
             "feature_display": "ABL1 p.E255K (Missense)"
         },
         {
@@ -3083,6 +3362,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 94,
+            "feature_id": 94,
+            "source_id": 47,
             "feature_display": "ABL1 p.E255V (Missense)"
         },
         {
@@ -3119,6 +3401,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 95,
+            "feature_id": 95,
+            "source_id": 47,
             "feature_display": "ABL1 p.F317L (Missense)"
         },
         {
@@ -3155,6 +3440,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 96,
+            "feature_id": 96,
+            "source_id": 47,
             "feature_display": "ABL1 p.F317V (Missense)"
         },
         {
@@ -3191,6 +3479,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 97,
+            "feature_id": 97,
+            "source_id": 47,
             "feature_display": "ABL1 p.F317I (Missense)"
         },
         {
@@ -3227,6 +3518,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 98,
+            "feature_id": 98,
+            "source_id": 47,
             "feature_display": "ABL1 p.F317C (Missense)"
         },
         {
@@ -3263,6 +3557,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 99,
+            "feature_id": 99,
+            "source_id": 47,
             "feature_display": "ABL1 p.F359V (Missense)"
         },
         {
@@ -3299,6 +3596,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 100,
+            "feature_id": 100,
+            "source_id": 47,
             "feature_display": "ABL1 p.F359C (Missense)"
         },
         {
@@ -3335,6 +3635,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 101,
+            "feature_id": 101,
+            "source_id": 47,
             "feature_display": "ABL1 p.T315A (Missense)"
         },
         {
@@ -3371,6 +3674,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 102,
+            "feature_id": 102,
+            "source_id": 47,
             "feature_display": "ABL1 p.Y253H (Missense)"
         },
         {
@@ -3407,6 +3713,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 103,
+            "feature_id": 103,
+            "source_id": 47,
             "feature_display": "ABL1 p.T315I (Missense)"
         },
         {
@@ -3443,6 +3752,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 104,
+            "feature_id": 104,
+            "source_id": 47,
             "feature_display": "ABL1 p.T315I (Missense)"
         },
         {
@@ -3479,6 +3791,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 105,
+            "feature_id": 105,
+            "source_id": 47,
             "feature_display": "ABL1 p.F359I (Missense)"
         },
         {
@@ -3515,6 +3830,9 @@
             "publication_date": "2015-11-03",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 106,
+            "feature_id": 106,
+            "source_id": 48,
             "feature_display": "AKT1 (Missense)"
         },
         {
@@ -3551,6 +3869,9 @@
             "publication_date": "2015-11-03",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 107,
+            "feature_id": 107,
+            "source_id": 48,
             "feature_display": "AKT1 p.E17K (Missense)"
         },
         {
@@ -3587,6 +3908,9 @@
             "publication_date": "2015-11-03",
             "last_updated": "2017-03-16",
             "_deprecated": false,
+            "assertion_id": 108,
+            "feature_id": 108,
+            "source_id": 49,
             "feature_display": "AKT2 (Missense)"
         },
         {
@@ -3623,6 +3947,9 @@
             "publication_date": "2015-11-03",
             "last_updated": "2017-03-16",
             "_deprecated": false,
+            "assertion_id": 109,
+            "feature_id": 109,
+            "source_id": 49,
             "feature_display": "AKT3 (Missense)"
         },
         {
@@ -3659,6 +3986,9 @@
             "publication_date": "2014-06-01",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 110,
+            "feature_id": 110,
+            "source_id": 50,
             "feature_display": "ALK p.G1202R (Missense)"
         },
         {
@@ -3695,6 +4025,9 @@
             "publication_date": "2014-06-01",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 111,
+            "feature_id": 111,
+            "source_id": 50,
             "feature_display": "ALK p.F1174C (Missense)"
         },
         {
@@ -3731,6 +4064,9 @@
             "publication_date": "2014-06-01",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 112,
+            "feature_id": 112,
+            "source_id": 50,
             "feature_display": "ALK p.L1196M (Missense)"
         },
         {
@@ -3767,6 +4103,9 @@
             "publication_date": "2014-06-01",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 113,
+            "feature_id": 113,
+            "source_id": 50,
             "feature_display": "ALK p.G1269A (Missense)"
         },
         {
@@ -3803,6 +4142,9 @@
             "publication_date": "2014-06-01",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 114,
+            "feature_id": 114,
+            "source_id": 50,
             "feature_display": "ALK p.S1206Y (Missense)"
         },
         {
@@ -3839,6 +4181,9 @@
             "publication_date": "2015-03-12",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 115,
+            "feature_id": 115,
+            "source_id": 51,
             "feature_display": "AR p.T878A (Missense)"
         },
         {
@@ -3875,6 +4220,9 @@
             "publication_date": "2015-03-12",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 116,
+            "feature_id": 116,
+            "source_id": 51,
             "feature_display": "AR p.L702H (Missense)"
         },
         {
@@ -3911,6 +4259,9 @@
             "publication_date": "2014-02-24",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 117,
+            "feature_id": 117,
+            "source_id": 52,
             "feature_display": "ARAF p.S214C (Missense)"
         },
         {
@@ -3947,6 +4298,9 @@
             "publication_date": "2018-05-07",
             "last_updated": "2019-02-04",
             "_deprecated": false,
+            "assertion_id": 118,
+            "feature_id": 118,
+            "source_id": 53,
             "feature_display": "ARID1A (Nonsense)"
         },
         {
@@ -3983,6 +4337,9 @@
             "publication_date": "2018-05-07",
             "last_updated": "2019-02-04",
             "_deprecated": false,
+            "assertion_id": 119,
+            "feature_id": 119,
+            "source_id": 53,
             "feature_display": "ARID1A (Frameshift)"
         },
         {
@@ -4019,6 +4376,9 @@
             "publication_date": "2015-04-09",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 120,
+            "feature_id": 120,
+            "source_id": 54,
             "feature_display": "ARID1A"
         },
         {
@@ -4055,6 +4415,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 121,
+            "feature_id": 121,
+            "source_id": 33,
             "feature_display": "ASXL1 (Nonsense)"
         },
         {
@@ -4091,6 +4454,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 122,
+            "feature_id": 122,
+            "source_id": 33,
             "feature_display": "ASXL1 (Frameshift)"
         },
         {
@@ -4122,11 +4488,14 @@
             "citation": "Yap TA, Tan DSP, Terbuch A, et al. First-in-Human Trial of the Oral Ataxia Telangiectasia and RAD3-Related (ATR) Inhibitor BAY 1895344 in Patients with Advanced Solid Tumors. Cancer Discovery. 2021;11(1):80-91.",
             "url": "https://doi.org/10.1158/2159-8290.CD-20-0868",
             "doi": "10.1158/2159-8290.CD-20-0868",
-            "pmid": "32988960",
+            "pmid": 32988960,
             "nct": "",
             "publication_date": "2021-01-06",
-            "last_updated": "2024-03-05",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 123,
+            "feature_id": 123,
+            "source_id": 55,
             "feature_display": "ATM (Frameshift)"
         },
         {
@@ -4158,11 +4527,14 @@
             "citation": "Yap TA, Tan DSP, Terbuch A, et al. First-in-Human Trial of the Oral Ataxia Telangiectasia and RAD3-Related (ATR) Inhibitor BAY 1895344 in Patients with Advanced Solid Tumors. Cancer Discovery. 2021;11(1):80-91.",
             "url": "https://doi.org/10.1158/2159-8290.CD-20-0868",
             "doi": "10.1158/2159-8290.CD-20-0868",
-            "pmid": "32988960",
+            "pmid": 32988960,
             "nct": "",
             "publication_date": "2021-01-06",
-            "last_updated": "2024-03-05",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 124,
+            "feature_id": 124,
+            "source_id": 55,
             "feature_display": "ATM (Splice Site)"
         },
         {
@@ -4194,11 +4566,14 @@
             "citation": "Yap TA, Tan DSP, Terbuch A, et al. First-in-Human Trial of the Oral Ataxia Telangiectasia and RAD3-Related (ATR) Inhibitor BAY 1895344 in Patients with Advanced Solid Tumors. Cancer Discovery. 2021;11(1):80-91.",
             "url": "https://doi.org/10.1158/2159-8290.CD-20-0868",
             "doi": "10.1158/2159-8290.CD-20-0868",
-            "pmid": "32988960",
+            "pmid": 32988960,
             "nct": "",
             "publication_date": "2021-01-06",
-            "last_updated": "2024-03-05",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 125,
+            "feature_id": 125,
+            "source_id": 55,
             "feature_display": "ATM (Nonsense)"
         },
         {
@@ -4235,6 +4610,9 @@
             "publication_date": "2016-12-31",
             "last_updated": "2019-08-08",
             "_deprecated": false,
+            "assertion_id": 126,
+            "feature_id": 126,
+            "source_id": 56,
             "feature_display": "ATM (Frameshift)"
         },
         {
@@ -4271,6 +4649,9 @@
             "publication_date": "2016-12-31",
             "last_updated": "2019-08-08",
             "_deprecated": false,
+            "assertion_id": 127,
+            "feature_id": 127,
+            "source_id": 56,
             "feature_display": "ATM (Splice Site)"
         },
         {
@@ -4307,6 +4688,9 @@
             "publication_date": "2016-12-31",
             "last_updated": "2019-08-08",
             "_deprecated": false,
+            "assertion_id": 128,
+            "feature_id": 128,
+            "source_id": 56,
             "feature_display": "ATM (Nonsense)"
         },
         {
@@ -4343,6 +4727,9 @@
             "publication_date": "2017-04-01",
             "last_updated": "2019-08-15",
             "_deprecated": false,
+            "assertion_id": 129,
+            "feature_id": 129,
+            "source_id": 57,
             "feature_display": "ATM p.A1127D (Missense)"
         },
         {
@@ -4379,6 +4766,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 130,
+            "feature_id": 130,
+            "source_id": 58,
             "feature_display": "ATM"
         },
         {
@@ -4415,6 +4805,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 131,
+            "feature_id": 131,
+            "source_id": 59,
             "feature_display": "BARD1"
         },
         {
@@ -4451,6 +4844,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 132,
+            "feature_id": 132,
+            "source_id": 59,
             "feature_display": "BARD1"
         },
         {
@@ -4487,6 +4883,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 133,
+            "feature_id": 133,
+            "source_id": 59,
             "feature_display": "BARD1"
         },
         {
@@ -4523,6 +4922,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 134,
+            "feature_id": 134,
+            "source_id": 59,
             "feature_display": "BARD1"
         },
         {
@@ -4559,6 +4961,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 135,
+            "feature_id": 135,
+            "source_id": 59,
             "feature_display": "BARD1"
         },
         {
@@ -4595,6 +5000,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 136,
+            "feature_id": 136,
+            "source_id": 59,
             "feature_display": "BARD1"
         },
         {
@@ -4631,6 +5039,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 137,
+            "feature_id": 137,
+            "source_id": 58,
             "feature_display": "BARD1"
         },
         {
@@ -4667,6 +5078,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 138,
+            "feature_id": 138,
+            "source_id": 33,
             "feature_display": "BCOR (Nonsense)"
         },
         {
@@ -4703,6 +5117,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 139,
+            "feature_id": 139,
+            "source_id": 33,
             "feature_display": "BCOR (Frameshift)"
         },
         {
@@ -4739,6 +5156,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 140,
+            "feature_id": 140,
+            "source_id": 33,
             "feature_display": "BCOR (Splice Site)"
         },
         {
@@ -4775,6 +5195,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 141,
+            "feature_id": 141,
+            "source_id": 60,
             "feature_display": "BCOR p.N1425S (Missense)"
         },
         {
@@ -4811,6 +5234,9 @@
             "publication_date": "2011-08-04",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 142,
+            "feature_id": 142,
+            "source_id": 46,
             "feature_display": "BCR"
         },
         {
@@ -4847,6 +5273,9 @@
             "publication_date": "2015-09-11",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 143,
+            "feature_id": 143,
+            "source_id": 61,
             "feature_display": "BLM"
         },
         {
@@ -4883,6 +5312,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 144,
+            "feature_id": 144,
+            "source_id": 62,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -4919,6 +5351,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 145,
+            "feature_id": 145,
+            "source_id": 62,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -4955,6 +5390,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 146,
+            "feature_id": 146,
+            "source_id": 62,
             "feature_display": "BRAF p.V600K (Missense)"
         },
         {
@@ -4991,6 +5429,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 147,
+            "feature_id": 147,
+            "source_id": 62,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5027,6 +5468,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 148,
+            "feature_id": 148,
+            "source_id": 62,
             "feature_display": "BRAF p.V600K (Missense)"
         },
         {
@@ -5063,6 +5507,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 149,
+            "feature_id": 149,
+            "source_id": 62,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5099,6 +5546,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 150,
+            "feature_id": 150,
+            "source_id": 63,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5135,6 +5585,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 151,
+            "feature_id": 151,
+            "source_id": 63,
             "feature_display": "BRAF p.V600K (Missense)"
         },
         {
@@ -5171,6 +5624,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2021-09-16",
             "_deprecated": false,
+            "assertion_id": 152,
+            "feature_id": 152,
+            "source_id": 64,
             "feature_display": "BRAF p.V600K (Missense)"
         },
         {
@@ -5207,6 +5663,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2021-09-16",
             "_deprecated": false,
+            "assertion_id": 153,
+            "feature_id": 153,
+            "source_id": 64,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5243,6 +5702,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 154,
+            "feature_id": 154,
+            "source_id": 64,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5279,6 +5741,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 155,
+            "feature_id": 155,
+            "source_id": 65,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5315,6 +5780,9 @@
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 156,
+            "feature_id": 156,
+            "source_id": 66,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5351,6 +5819,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 157,
+            "feature_id": 157,
+            "source_id": 67,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5387,6 +5858,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 158,
+            "feature_id": 158,
+            "source_id": 68,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5423,6 +5897,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 159,
+            "feature_id": 159,
+            "source_id": 68,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5459,6 +5936,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 160,
+            "feature_id": 160,
+            "source_id": 68,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5495,6 +5975,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 161,
+            "feature_id": 161,
+            "source_id": 68,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5531,6 +6014,9 @@
             "publication_date": "2016-08-16",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 162,
+            "feature_id": 162,
+            "source_id": 69,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5567,6 +6053,9 @@
             "publication_date": "2016-08-16",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 163,
+            "feature_id": 163,
+            "source_id": 69,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5603,6 +6092,9 @@
             "publication_date": "2016-06-30",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 164,
+            "feature_id": 164,
+            "source_id": 70,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5639,6 +6131,9 @@
             "publication_date": "2016-06-30",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 165,
+            "feature_id": 165,
+            "source_id": 70,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5675,6 +6170,9 @@
             "publication_date": "2009-12-1",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 166,
+            "feature_id": 166,
+            "source_id": 71,
             "feature_display": "BRAF"
         },
         {
@@ -5711,6 +6209,9 @@
             "publication_date": "2016-10-01",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 167,
+            "feature_id": 167,
+            "source_id": 72,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5747,6 +6248,9 @@
             "publication_date": "2017-02-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 168,
+            "feature_id": 168,
+            "source_id": 73,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5783,6 +6287,9 @@
             "publication_date": "2015-08-20",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 169,
+            "feature_id": 169,
+            "source_id": 74,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5819,6 +6326,9 @@
             "publication_date": "2015-08-20",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 170,
+            "feature_id": 170,
+            "source_id": 74,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5855,6 +6365,9 @@
             "publication_date": "2015-08-20",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 171,
+            "feature_id": 171,
+            "source_id": 74,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5891,6 +6404,9 @@
             "publication_date": "2016-09-28",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 172,
+            "feature_id": 172,
+            "source_id": 75,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5927,6 +6443,9 @@
             "publication_date": "2016-06-02",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 173,
+            "feature_id": 173,
+            "source_id": 76,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5963,6 +6482,9 @@
             "publication_date": "2016-06-02",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 174,
+            "feature_id": 174,
+            "source_id": 76,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -5999,6 +6521,9 @@
             "publication_date": "2016-10-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 175,
+            "feature_id": 175,
+            "source_id": 77,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -6035,6 +6560,9 @@
             "publication_date": "2014-01-07",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 176,
+            "feature_id": 176,
+            "source_id": 78,
             "feature_display": "BRAF"
         },
         {
@@ -6071,6 +6599,9 @@
             "publication_date": "2014-01-07",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 177,
+            "feature_id": 177,
+            "source_id": 78,
             "feature_display": "BRAF"
         },
         {
@@ -6107,6 +6638,9 @@
             "publication_date": "2014-01-07",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 178,
+            "feature_id": 178,
+            "source_id": 78,
             "feature_display": "BRAF"
         },
         {
@@ -6143,6 +6677,9 @@
             "publication_date": "2014-01-07",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 179,
+            "feature_id": 179,
+            "source_id": 78,
             "feature_display": "BRAF"
         },
         {
@@ -6179,6 +6716,9 @@
             "publication_date": "2015-04-09",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 180,
+            "feature_id": 180,
+            "source_id": 54,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -6215,6 +6755,9 @@
             "publication_date": "2015-05-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 181,
+            "feature_id": 181,
+            "source_id": 79,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -6251,6 +6794,9 @@
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 182,
+            "feature_id": 182,
+            "source_id": 66,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -6287,6 +6833,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 183,
+            "feature_id": 183,
+            "source_id": 80,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -6323,6 +6872,9 @@
             "publication_date": "2015-08-20",
             "last_updated": "2019-10-04",
             "_deprecated": false,
+            "assertion_id": 184,
+            "feature_id": 184,
+            "source_id": 74,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -6359,6 +6911,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 185,
+            "feature_id": 185,
+            "source_id": 81,
             "feature_display": "BRCA1"
         },
         {
@@ -6395,6 +6950,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 186,
+            "feature_id": 186,
+            "source_id": 81,
             "feature_display": "BRCA1"
         },
         {
@@ -6431,6 +6989,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 187,
+            "feature_id": 187,
+            "source_id": 81,
             "feature_display": "BRCA1"
         },
         {
@@ -6467,6 +7028,9 @@
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 188,
+            "feature_id": 188,
+            "source_id": 82,
             "feature_display": "BRCA1"
         },
         {
@@ -6503,6 +7067,9 @@
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 189,
+            "feature_id": 189,
+            "source_id": 82,
             "feature_display": "BRCA1"
         },
         {
@@ -6539,6 +7106,9 @@
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 190,
+            "feature_id": 190,
+            "source_id": 82,
             "feature_display": "BRCA1"
         },
         {
@@ -6575,6 +7145,9 @@
             "publication_date": "2010-04-20",
             "last_updated": "2019-03-20",
             "_deprecated": false,
+            "assertion_id": 191,
+            "feature_id": 191,
+            "source_id": 83,
             "feature_display": "BRCA1"
         },
         {
@@ -6611,6 +7184,9 @@
             "publication_date": "2017-02-21",
             "last_updated": "2019-03-20",
             "_deprecated": false,
+            "assertion_id": 192,
+            "feature_id": 192,
+            "source_id": 84,
             "feature_display": "BRCA1"
         },
         {
@@ -6647,6 +7223,9 @@
             "publication_date": "2015-02-25",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 193,
+            "feature_id": 193,
+            "source_id": 85,
             "feature_display": "BRCA1"
         },
         {
@@ -6683,6 +7262,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 194,
+            "feature_id": 194,
+            "source_id": 86,
             "feature_display": "BRCA1"
         },
         {
@@ -6719,6 +7301,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 195,
+            "feature_id": 195,
+            "source_id": 86,
             "feature_display": "BRCA1"
         },
         {
@@ -6755,6 +7340,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 196,
+            "feature_id": 196,
+            "source_id": 86,
             "feature_display": "BRCA1"
         },
         {
@@ -6791,6 +7379,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 197,
+            "feature_id": 197,
+            "source_id": 58,
             "feature_display": "BRCA1"
         },
         {
@@ -6827,6 +7418,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 198,
+            "feature_id": 198,
+            "source_id": 87,
             "feature_display": "BRCA1"
         },
         {
@@ -6863,6 +7457,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 199,
+            "feature_id": 199,
+            "source_id": 87,
             "feature_display": "BRCA1"
         },
         {
@@ -6899,6 +7496,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 200,
+            "feature_id": 200,
+            "source_id": 87,
             "feature_display": "BRCA1"
         },
         {
@@ -6935,6 +7535,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 201,
+            "feature_id": 201,
+            "source_id": 86,
             "feature_display": "BRCA2"
         },
         {
@@ -6971,6 +7574,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 202,
+            "feature_id": 202,
+            "source_id": 86,
             "feature_display": "BRCA2"
         },
         {
@@ -7007,6 +7613,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 203,
+            "feature_id": 203,
+            "source_id": 86,
             "feature_display": "BRCA2"
         },
         {
@@ -7043,6 +7652,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 204,
+            "feature_id": 204,
+            "source_id": 81,
             "feature_display": "BRCA2"
         },
         {
@@ -7079,6 +7691,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 205,
+            "feature_id": 205,
+            "source_id": 81,
             "feature_display": "BRCA2"
         },
         {
@@ -7115,6 +7730,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 206,
+            "feature_id": 206,
+            "source_id": 81,
             "feature_display": "BRCA2"
         },
         {
@@ -7151,6 +7769,9 @@
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 207,
+            "feature_id": 207,
+            "source_id": 82,
             "feature_display": "BRCA2"
         },
         {
@@ -7187,6 +7808,9 @@
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 208,
+            "feature_id": 208,
+            "source_id": 82,
             "feature_display": "BRCA2"
         },
         {
@@ -7223,6 +7847,9 @@
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 209,
+            "feature_id": 209,
+            "source_id": 82,
             "feature_display": "BRCA2"
         },
         {
@@ -7259,6 +7886,9 @@
             "publication_date": "2010-04-20",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 210,
+            "feature_id": 210,
+            "source_id": 83,
             "feature_display": "BRCA2"
         },
         {
@@ -7295,6 +7925,9 @@
             "publication_date": "2017-02-21",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 211,
+            "feature_id": 211,
+            "source_id": 84,
             "feature_display": "BRCA2"
         },
         {
@@ -7331,6 +7964,9 @@
             "publication_date": "2015-10-29",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 212,
+            "feature_id": 212,
+            "source_id": 88,
             "feature_display": "BRCA2"
         },
         {
@@ -7367,6 +8003,9 @@
             "publication_date": "2015-02-25",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 213,
+            "feature_id": 213,
+            "source_id": 85,
             "feature_display": "BRCA2"
         },
         {
@@ -7403,6 +8042,9 @@
             "publication_date": "2016-03-24",
             "last_updated": "2019-04-16",
             "_deprecated": false,
+            "assertion_id": 214,
+            "feature_id": 214,
+            "source_id": 89,
             "feature_display": "BRCA2 (Nonsense)"
         },
         {
@@ -7439,6 +8081,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 215,
+            "feature_id": 215,
+            "source_id": 58,
             "feature_display": "BRCA2"
         },
         {
@@ -7475,6 +8120,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 216,
+            "feature_id": 216,
+            "source_id": 87,
             "feature_display": "BRCA2"
         },
         {
@@ -7511,6 +8159,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 217,
+            "feature_id": 217,
+            "source_id": 87,
             "feature_display": "BRCA2"
         },
         {
@@ -7547,6 +8198,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 218,
+            "feature_id": 218,
+            "source_id": 87,
             "feature_display": "BRCA2"
         },
         {
@@ -7583,6 +8237,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 219,
+            "feature_id": 219,
+            "source_id": 59,
             "feature_display": "BRIP1"
         },
         {
@@ -7619,6 +8276,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 220,
+            "feature_id": 220,
+            "source_id": 59,
             "feature_display": "BRIP1"
         },
         {
@@ -7655,6 +8315,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 221,
+            "feature_id": 221,
+            "source_id": 59,
             "feature_display": "BRIP1"
         },
         {
@@ -7691,6 +8354,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 222,
+            "feature_id": 222,
+            "source_id": 59,
             "feature_display": "BRIP1"
         },
         {
@@ -7727,6 +8393,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 223,
+            "feature_id": 223,
+            "source_id": 59,
             "feature_display": "BRIP1"
         },
         {
@@ -7763,6 +8432,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 224,
+            "feature_id": 224,
+            "source_id": 59,
             "feature_display": "BRIP1"
         },
         {
@@ -7799,6 +8471,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 225,
+            "feature_id": 225,
+            "source_id": 58,
             "feature_display": "BRIP1"
         },
         {
@@ -7835,6 +8510,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 226,
+            "feature_id": 226,
+            "source_id": 58,
             "feature_display": "CDK12"
         },
         {
@@ -7871,6 +8549,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 227,
+            "feature_id": 227,
+            "source_id": 59,
             "feature_display": "CHEK1"
         },
         {
@@ -7907,6 +8588,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 228,
+            "feature_id": 228,
+            "source_id": 59,
             "feature_display": "CHEK1"
         },
         {
@@ -7943,6 +8627,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 229,
+            "feature_id": 229,
+            "source_id": 59,
             "feature_display": "CHEK1"
         },
         {
@@ -7979,6 +8666,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 230,
+            "feature_id": 230,
+            "source_id": 59,
             "feature_display": "CHEK1"
         },
         {
@@ -8015,6 +8705,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 231,
+            "feature_id": 231,
+            "source_id": 59,
             "feature_display": "CHEK1"
         },
         {
@@ -8051,6 +8744,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 232,
+            "feature_id": 232,
+            "source_id": 59,
             "feature_display": "CHEK1"
         },
         {
@@ -8087,6 +8783,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 233,
+            "feature_id": 233,
+            "source_id": 58,
             "feature_display": "CHEK1"
         },
         {
@@ -8123,6 +8822,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 234,
+            "feature_id": 234,
+            "source_id": 59,
             "feature_display": "CHEK2"
         },
         {
@@ -8159,6 +8861,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 235,
+            "feature_id": 235,
+            "source_id": 59,
             "feature_display": "CHEK2"
         },
         {
@@ -8195,6 +8900,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 236,
+            "feature_id": 236,
+            "source_id": 59,
             "feature_display": "CHEK2"
         },
         {
@@ -8231,6 +8939,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 237,
+            "feature_id": 237,
+            "source_id": 59,
             "feature_display": "CHEK2"
         },
         {
@@ -8267,6 +8978,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 238,
+            "feature_id": 238,
+            "source_id": 59,
             "feature_display": "CHEK2"
         },
         {
@@ -8303,6 +9017,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 239,
+            "feature_id": 239,
+            "source_id": 59,
             "feature_display": "CHEK2"
         },
         {
@@ -8339,6 +9056,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 240,
+            "feature_id": 240,
+            "source_id": 58,
             "feature_display": "CHEK2"
         },
         {
@@ -8375,6 +9095,9 @@
             "publication_date": "2010-09-07",
             "last_updated": "2019-09-12",
             "_deprecated": false,
+            "assertion_id": 241,
+            "feature_id": 241,
+            "source_id": 90,
             "feature_display": "CTNNB1"
         },
         {
@@ -8411,6 +9134,9 @@
             "publication_date": "2017-03-30",
             "last_updated": "2024-10-02",
             "_deprecated": false,
+            "assertion_id": 242,
+            "feature_id": 242,
+            "source_id": 91,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8447,6 +9173,9 @@
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 243,
+            "feature_id": 243,
+            "source_id": 20,
             "feature_display": "EGFR"
         },
         {
@@ -8483,6 +9212,9 @@
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 244,
+            "feature_id": 244,
+            "source_id": 20,
             "feature_display": "EGFR"
         },
         {
@@ -8519,6 +9251,9 @@
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 245,
+            "feature_id": 245,
+            "source_id": 20,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8555,6 +9290,9 @@
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 246,
+            "feature_id": 246,
+            "source_id": 20,
             "feature_display": "EGFR"
         },
         {
@@ -8591,6 +9329,9 @@
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 247,
+            "feature_id": 247,
+            "source_id": 20,
             "feature_display": "EGFR"
         },
         {
@@ -8627,6 +9368,9 @@
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 248,
+            "feature_id": 248,
+            "source_id": 20,
             "feature_display": "EGFR Exon 20 (Insertion)"
         },
         {
@@ -8663,6 +9407,9 @@
             "publication_date": "2016-04-15",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 249,
+            "feature_id": 249,
+            "source_id": 92,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8699,6 +9446,9 @@
             "publication_date": "2016-04-15",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 250,
+            "feature_id": 250,
+            "source_id": 93,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8735,6 +9485,9 @@
             "publication_date": "2016-10-04",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 251,
+            "feature_id": 251,
+            "source_id": 94,
             "feature_display": "EGFR"
         },
         {
@@ -8771,6 +9524,9 @@
             "publication_date": "2016-10-04",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 252,
+            "feature_id": 252,
+            "source_id": 94,
             "feature_display": "EGFR"
         },
         {
@@ -8807,6 +9563,9 @@
             "publication_date": "2016-10-04",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 253,
+            "feature_id": 253,
+            "source_id": 94,
             "feature_display": "EGFR"
         },
         {
@@ -8843,6 +9602,9 @@
             "publication_date": "2016-10-04",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 254,
+            "feature_id": 254,
+            "source_id": 94,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -8879,6 +9641,9 @@
             "publication_date": "2016-10-04",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 255,
+            "feature_id": 255,
+            "source_id": 94,
             "feature_display": "EGFR"
         },
         {
@@ -8915,6 +9680,9 @@
             "publication_date": "2016-10-04",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 256,
+            "feature_id": 256,
+            "source_id": 94,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8951,6 +9719,9 @@
             "publication_date": "2015-04-30",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 257,
+            "feature_id": 257,
+            "source_id": 95,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -8980,13 +9751,16 @@
             "description": "Amplification and mutation of EGFR was associated with better clinical outcomes in a trial of 66 non-small cell lung cancer patients who had experienced relapse after surgery.",
             "source_type": "Journal",
             "citation": "Takano T, Ohe Y, Sakamoto H, et al. Epidermal growth factor receptor gene mutations and increased copy numbers predict gefitinib sensitivity in patients with recurrent non-small-cell lung cancer. J Clin Oncol. 2005;23(28):6829-37.",
-            "url": "https://doi.org/10.1200/JCO.20051793",
-            "doi": "10.1200/JCO.20051793",
+            "url": "https://doi.org/10.1200/JCO.2005.01.0793",
+            "doi": "10.1200/JCO.2005.01.0793",
             "pmid": 15998907,
             "nct": "",
             "publication_date": "2005-10-01",
-            "last_updated": "2017-11-03",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 258,
+            "feature_id": 258,
+            "source_id": 96,
             "feature_display": "EGFR"
         },
         {
@@ -9023,6 +9797,9 @@
             "publication_date": "2016-04-12",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 259,
+            "feature_id": 259,
+            "source_id": 97,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -9059,6 +9836,9 @@
             "publication_date": "2016-04-12",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 260,
+            "feature_id": 260,
+            "source_id": 97,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -9095,6 +9875,9 @@
             "publication_date": "2016-04-12",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 261,
+            "feature_id": 261,
+            "source_id": 97,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -9131,6 +9914,9 @@
             "publication_date": "2016-04-12",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 262,
+            "feature_id": 262,
+            "source_id": 97,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -9167,6 +9953,9 @@
             "publication_date": "2016-04-12",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 263,
+            "feature_id": 263,
+            "source_id": 97,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -9203,6 +9992,9 @@
             "publication_date": "2014-02-01",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 264,
+            "feature_id": 264,
+            "source_id": 98,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -9239,6 +10031,9 @@
             "publication_date": "2014-02-01",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 265,
+            "feature_id": 265,
+            "source_id": 98,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -9275,6 +10070,9 @@
             "publication_date": "2019-10-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 266,
+            "feature_id": 266,
+            "source_id": 99,
             "feature_display": "EGFR"
         },
         {
@@ -9311,6 +10109,9 @@
             "publication_date": "2019-10-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 267,
+            "feature_id": 267,
+            "source_id": 99,
             "feature_display": "EGFR (Nonsense)"
         },
         {
@@ -9347,6 +10148,9 @@
             "publication_date": "2019-10-01",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 268,
+            "feature_id": 268,
+            "source_id": 99,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -9383,6 +10187,9 @@
             "publication_date": "2013-10-01",
             "last_updated": "2019-08-09",
             "_deprecated": false,
+            "assertion_id": 269,
+            "feature_id": 269,
+            "source_id": 19,
             "feature_display": "EGFR"
         },
         {
@@ -9419,6 +10226,9 @@
             "publication_date": "2018-01-11",
             "last_updated": "2019-08-15",
             "_deprecated": false,
+            "assertion_id": 270,
+            "feature_id": 270,
+            "source_id": 100,
             "feature_display": "EGFR Exon 19 (Nonsense)"
         },
         {
@@ -9455,6 +10265,9 @@
             "publication_date": "2018-01-11",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 271,
+            "feature_id": 271,
+            "source_id": 100,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -9491,6 +10304,9 @@
             "publication_date": "2020-12-11",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 272,
+            "feature_id": 272,
+            "source_id": 101,
             "feature_display": "EGFR Exon 19 (Deletion)"
         },
         {
@@ -9527,6 +10343,9 @@
             "publication_date": "2020-12-11",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 273,
+            "feature_id": 273,
+            "source_id": 101,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -9563,6 +10382,9 @@
             "publication_date": "2021-05-21",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 274,
+            "feature_id": 274,
+            "source_id": 102,
             "feature_display": "EGFR Exon 20 (Insertion)"
         },
         {
@@ -9599,6 +10421,9 @@
             "publication_date": "2021-09-01",
             "last_updated": "2021-09-16",
             "_deprecated": false,
+            "assertion_id": 275,
+            "feature_id": 275,
+            "source_id": 103,
             "feature_display": "EGFR Exon 20 (Insertion)"
         },
         {
@@ -9635,6 +10460,9 @@
             "publication_date": "2018-01-31",
             "last_updated": "2018-09-10",
             "_deprecated": false,
+            "assertion_id": 276,
+            "feature_id": 276,
+            "source_id": 104,
             "feature_display": "ERBB2 (Missense)"
         },
         {
@@ -9671,6 +10499,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 277,
+            "feature_id": 277,
+            "source_id": 11,
             "feature_display": "ERBB2"
         },
         {
@@ -9707,6 +10538,9 @@
             "publication_date": "2018-01-31",
             "last_updated": "2018-09-10",
             "_deprecated": false,
+            "assertion_id": 278,
+            "feature_id": 278,
+            "source_id": 104,
             "feature_display": "ERBB3 (Missense)"
         },
         {
@@ -9743,6 +10577,9 @@
             "publication_date": "2016-06-16",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 279,
+            "feature_id": 279,
+            "source_id": 105,
             "feature_display": "ERCC2 (Missense)"
         },
         {
@@ -9779,6 +10616,9 @@
             "publication_date": "2014-09-30",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 280,
+            "feature_id": 280,
+            "source_id": 106,
             "feature_display": "ERCC2 (Missense)"
         },
         {
@@ -9815,6 +10655,9 @@
             "publication_date": "2014-02-13",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 281,
+            "feature_id": 281,
+            "source_id": 23,
             "feature_display": "ERRFI1 p.E384* (Nonsense)"
         },
         {
@@ -9851,6 +10694,9 @@
             "publication_date": "2013-11-03",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 282,
+            "feature_id": 282,
+            "source_id": 107,
             "feature_display": "ESR1"
         },
         {
@@ -9887,6 +10733,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 283,
+            "feature_id": 283,
+            "source_id": 33,
             "feature_display": "ETV6 (Nonsense)"
         },
         {
@@ -9923,6 +10772,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 284,
+            "feature_id": 284,
+            "source_id": 33,
             "feature_display": "ETV6 (Frameshift)"
         },
         {
@@ -9959,6 +10811,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 285,
+            "feature_id": 285,
+            "source_id": 33,
             "feature_display": "EZH2 (Nonsense)"
         },
         {
@@ -9995,6 +10850,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 286,
+            "feature_id": 286,
+            "source_id": 33,
             "feature_display": "EZH2 (Frameshift)"
         },
         {
@@ -10031,6 +10889,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-10",
             "_deprecated": false,
+            "assertion_id": 287,
+            "feature_id": 287,
+            "source_id": 108,
             "feature_display": "EZH2 p.Y646* (Nonsense)"
         },
         {
@@ -10067,6 +10928,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-10",
             "_deprecated": false,
+            "assertion_id": 288,
+            "feature_id": 288,
+            "source_id": 108,
             "feature_display": "EZH2 p.Y646F (Missense)"
         },
         {
@@ -10103,6 +10967,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-10",
             "_deprecated": false,
+            "assertion_id": 289,
+            "feature_id": 289,
+            "source_id": 108,
             "feature_display": "EZH2 p.Y646N (Missense)"
         },
         {
@@ -10139,6 +11006,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-10",
             "_deprecated": false,
+            "assertion_id": 290,
+            "feature_id": 290,
+            "source_id": 108,
             "feature_display": "EZH2 p.A682G (Missense)"
         },
         {
@@ -10175,6 +11045,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-10",
             "_deprecated": false,
+            "assertion_id": 291,
+            "feature_id": 291,
+            "source_id": 108,
             "feature_display": "EZH2 p.A692V (Missense)"
         },
         {
@@ -10211,6 +11084,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 292,
+            "feature_id": 292,
+            "source_id": 58,
             "feature_display": "FANCL"
         },
         {
@@ -10247,6 +11123,9 @@
             "publication_date": "2008-09-12",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 293,
+            "feature_id": 293,
+            "source_id": 109,
             "feature_display": "FBXW7 (Missense)"
         },
         {
@@ -10283,6 +11162,9 @@
             "publication_date": "2024-01-19",
             "last_updated": "2024-01-25",
             "_deprecated": false,
+            "assertion_id": 294,
+            "feature_id": 294,
+            "source_id": 26,
             "feature_display": "FGFR3 p.R248C (Missense)"
         },
         {
@@ -10319,6 +11201,9 @@
             "publication_date": "2024-01-19",
             "last_updated": "2024-01-25",
             "_deprecated": false,
+            "assertion_id": 295,
+            "feature_id": 295,
+            "source_id": 26,
             "feature_display": "FGFR3 p.S249C (Missense)"
         },
         {
@@ -10355,6 +11240,9 @@
             "publication_date": "2024-01-19",
             "last_updated": "2024-01-25",
             "_deprecated": false,
+            "assertion_id": 296,
+            "feature_id": 296,
+            "source_id": 26,
             "feature_display": "FGFR3 p.G370C (Missense)"
         },
         {
@@ -10391,6 +11279,9 @@
             "publication_date": "2024-01-19",
             "last_updated": "2024-01-25",
             "_deprecated": false,
+            "assertion_id": 297,
+            "feature_id": 297,
+            "source_id": 26,
             "feature_display": "FGFR3 p.Y373C (Missense)"
         },
         {
@@ -10427,6 +11318,9 @@
             "publication_date": "2012-08-23",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 298,
+            "feature_id": 298,
+            "source_id": 110,
             "feature_display": "FLCN (Nonsense)"
         },
         {
@@ -10463,6 +11357,9 @@
             "publication_date": "2012-08-23",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 299,
+            "feature_id": 299,
+            "source_id": 110,
             "feature_display": "FLCN (Nonsense)"
         },
         {
@@ -10499,6 +11396,9 @@
             "publication_date": "2014-10-09",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 300,
+            "feature_id": 300,
+            "source_id": 111,
             "feature_display": "FLCN (Nonsense)"
         },
         {
@@ -10535,6 +11435,9 @@
             "publication_date": "2014-10-09",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 301,
+            "feature_id": 301,
+            "source_id": 111,
             "feature_display": "FLCN (Frameshift)"
         },
         {
@@ -10571,6 +11474,9 @@
             "publication_date": "2014-10-09",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 302,
+            "feature_id": 302,
+            "source_id": 111,
             "feature_display": "FLCN (Frameshift)"
         },
         {
@@ -10607,6 +11513,9 @@
             "publication_date": "2014-10-09",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 303,
+            "feature_id": 303,
+            "source_id": 111,
             "feature_display": "FLCN (Frameshift)"
         },
         {
@@ -10643,6 +11552,9 @@
             "publication_date": "2013-01-16",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 304,
+            "feature_id": 304,
+            "source_id": 112,
             "feature_display": "FLT3 p.F691L (Missense)"
         },
         {
@@ -10679,6 +11591,9 @@
             "publication_date": "2006-09-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 305,
+            "feature_id": 305,
+            "source_id": 113,
             "feature_display": "FLT3 p.K663Q (Missense)"
         },
         {
@@ -10715,6 +11630,9 @@
             "publication_date": "2012-06-10",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 306,
+            "feature_id": 306,
+            "source_id": 114,
             "feature_display": "GATA3 p.M294K (Missense)"
         },
         {
@@ -10751,6 +11669,9 @@
             "publication_date": "2018-07-20",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 307,
+            "feature_id": 307,
+            "source_id": 115,
             "feature_display": "IDH1"
         },
         {
@@ -10787,6 +11708,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 308,
+            "feature_id": 308,
+            "source_id": 116,
             "feature_display": "IDH1"
         },
         {
@@ -10823,6 +11747,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 309,
+            "feature_id": 309,
+            "source_id": 116,
             "feature_display": "IDH1"
         },
         {
@@ -10859,6 +11786,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 310,
+            "feature_id": 310,
+            "source_id": 117,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -10895,6 +11825,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 311,
+            "feature_id": 311,
+            "source_id": 117,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -10931,6 +11864,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 312,
+            "feature_id": 312,
+            "source_id": 117,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -10967,6 +11903,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 313,
+            "feature_id": 313,
+            "source_id": 117,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -11003,6 +11942,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 314,
+            "feature_id": 314,
+            "source_id": 117,
             "feature_display": "IDH1"
         },
         {
@@ -11039,6 +11981,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 315,
+            "feature_id": 315,
+            "source_id": 117,
             "feature_display": "IDH1"
         },
         {
@@ -11075,6 +12020,9 @@
             "publication_date": "2019-09-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 316,
+            "feature_id": 316,
+            "source_id": 118,
             "feature_display": "IDH2 p.R140Q (Missense)"
         },
         {
@@ -11111,6 +12059,9 @@
             "publication_date": "2019-09-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 317,
+            "feature_id": 317,
+            "source_id": 118,
             "feature_display": "IDH2 p.R172S (Missense)"
         },
         {
@@ -11147,6 +12098,9 @@
             "publication_date": "2019-09-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 318,
+            "feature_id": 318,
+            "source_id": 118,
             "feature_display": "IDH2 p.R172K (Missense)"
         },
         {
@@ -11183,6 +12137,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 319,
+            "feature_id": 319,
+            "source_id": 116,
             "feature_display": "IDH2"
         },
         {
@@ -11219,6 +12176,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 320,
+            "feature_id": 320,
+            "source_id": 116,
             "feature_display": "IDH2"
         },
         {
@@ -11255,6 +12215,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 321,
+            "feature_id": 321,
+            "source_id": 33,
             "feature_display": "IDH2 p.R140Q (Missense)"
         },
         {
@@ -11291,6 +12254,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 322,
+            "feature_id": 322,
+            "source_id": 33,
             "feature_display": "IDH2 p.R172S (Missense)"
         },
         {
@@ -11327,6 +12293,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 323,
+            "feature_id": 323,
+            "source_id": 33,
             "feature_display": "IDH2 p.R172K (Missense)"
         },
         {
@@ -11363,6 +12332,9 @@
             "publication_date": "2017-02-28",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 324,
+            "feature_id": 324,
+            "source_id": 119,
             "feature_display": "JAK1"
         },
         {
@@ -11399,6 +12371,9 @@
             "publication_date": "2015-11-26",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 325,
+            "feature_id": 325,
+            "source_id": 120,
             "feature_display": "JAK1 p.V656F (Missense)"
         },
         {
@@ -11435,6 +12410,9 @@
             "publication_date": "2015-11-26",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 326,
+            "feature_id": 326,
+            "source_id": 120,
             "feature_display": "JAK1 p.A634D (Missense)"
         },
         {
@@ -11471,6 +12449,9 @@
             "publication_date": "2017-02-28",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 327,
+            "feature_id": 327,
+            "source_id": 119,
             "feature_display": "JAK2"
         },
         {
@@ -11507,6 +12488,9 @@
             "publication_date": "2005-04-28",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 328,
+            "feature_id": 328,
+            "source_id": 121,
             "feature_display": "JAK2 p.V617F (Missense)"
         },
         {
@@ -11543,6 +12527,9 @@
             "publication_date": "2014-11-13",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 329,
+            "feature_id": 329,
+            "source_id": 122,
             "feature_display": "JAK3 p.A572T (Missense)"
         },
         {
@@ -11579,6 +12566,9 @@
             "publication_date": "2014-11-13",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 330,
+            "feature_id": 330,
+            "source_id": 122,
             "feature_display": "JAK3 p.M511I (Missense)"
         },
         {
@@ -11615,6 +12605,9 @@
             "publication_date": "2014-11-13",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 331,
+            "feature_id": 331,
+            "source_id": 122,
             "feature_display": "JAK3 p.L857Q (Missense)"
         },
         {
@@ -11651,6 +12644,9 @@
             "publication_date": "2014-11-13",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 332,
+            "feature_id": 332,
+            "source_id": 122,
             "feature_display": "JAK3 p.A572T (Missense)"
         },
         {
@@ -11687,6 +12683,9 @@
             "publication_date": "2014-11-13",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 333,
+            "feature_id": 333,
+            "source_id": 122,
             "feature_display": "JAK3 p.M511I (Missense)"
         },
         {
@@ -11723,6 +12722,9 @@
             "publication_date": "2014-11-13",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 334,
+            "feature_id": 334,
+            "source_id": 122,
             "feature_display": "JAK3 p.L857Q (Missense)"
         },
         {
@@ -11759,6 +12761,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 335,
+            "feature_id": 335,
+            "source_id": 3,
             "feature_display": "KIT"
         },
         {
@@ -11795,6 +12800,9 @@
             "publication_date": "2020-08-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 336,
+            "feature_id": 336,
+            "source_id": 3,
             "feature_display": "KIT"
         },
         {
@@ -11831,6 +12839,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 337,
+            "feature_id": 337,
+            "source_id": 123,
             "feature_display": "KIT"
         },
         {
@@ -11867,6 +12878,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 338,
+            "feature_id": 338,
+            "source_id": 123,
             "feature_display": "KIT"
         },
         {
@@ -11903,6 +12917,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 339,
+            "feature_id": 339,
+            "source_id": 123,
             "feature_display": "KIT p.T670I (Missense)"
         },
         {
@@ -11939,6 +12956,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 340,
+            "feature_id": 340,
+            "source_id": 123,
             "feature_display": "KIT p.V654A (Missense)"
         },
         {
@@ -11975,6 +12995,9 @@
             "publication_date": "2020-08-14",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 341,
+            "feature_id": 341,
+            "source_id": 124,
             "feature_display": "KIT"
         },
         {
@@ -12011,6 +13034,9 @@
             "publication_date": "2020-08-14",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 342,
+            "feature_id": 342,
+            "source_id": 124,
             "feature_display": "KIT p.T670I (Missense)"
         },
         {
@@ -12047,6 +13073,9 @@
             "publication_date": "2020-08-14",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 343,
+            "feature_id": 343,
+            "source_id": 124,
             "feature_display": "KIT p.V654A (Missense)"
         },
         {
@@ -12083,6 +13112,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 344,
+            "feature_id": 344,
+            "source_id": 125,
             "feature_display": "KIT"
         },
         {
@@ -12119,6 +13151,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 345,
+            "feature_id": 345,
+            "source_id": 126,
             "feature_display": "KIT Exon 11"
         },
         {
@@ -12155,6 +13190,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 346,
+            "feature_id": 346,
+            "source_id": 126,
             "feature_display": "KIT Exon 13"
         },
         {
@@ -12191,6 +13229,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 347,
+            "feature_id": 347,
+            "source_id": 126,
             "feature_display": "KIT p.W557C (Missense)"
         },
         {
@@ -12227,6 +13268,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 348,
+            "feature_id": 348,
+            "source_id": 126,
             "feature_display": "KIT p.W557G (Missense)"
         },
         {
@@ -12263,6 +13307,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 349,
+            "feature_id": 349,
+            "source_id": 126,
             "feature_display": "KIT p.W557R (Missense)"
         },
         {
@@ -12299,6 +13346,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 350,
+            "feature_id": 350,
+            "source_id": 126,
             "feature_display": "KIT p.V559A (Missense)"
         },
         {
@@ -12335,6 +13385,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 351,
+            "feature_id": 351,
+            "source_id": 126,
             "feature_display": "KIT p.V559G (Missense)"
         },
         {
@@ -12371,6 +13424,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 352,
+            "feature_id": 352,
+            "source_id": 126,
             "feature_display": "KIT p.L576P (Missense)"
         },
         {
@@ -12407,6 +13463,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 353,
+            "feature_id": 353,
+            "source_id": 126,
             "feature_display": "KIT p.K642E (Missense)"
         },
         {
@@ -12443,6 +13502,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 354,
+            "feature_id": 354,
+            "source_id": 126,
             "feature_display": "KIT Exon 17"
         },
         {
@@ -12479,6 +13541,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 355,
+            "feature_id": 355,
+            "source_id": 126,
             "feature_display": "KIT p.D816H (Missense)"
         },
         {
@@ -12515,6 +13580,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 356,
+            "feature_id": 356,
+            "source_id": 68,
             "feature_display": "KIT"
         },
         {
@@ -12551,6 +13619,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 357,
+            "feature_id": 357,
+            "source_id": 127,
             "feature_display": "KIT Exon 11"
         },
         {
@@ -12587,6 +13658,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 358,
+            "feature_id": 358,
+            "source_id": 127,
             "feature_display": "KIT Exon 9"
         },
         {
@@ -12623,6 +13697,9 @@
             "publication_date": "2020-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 359,
+            "feature_id": 359,
+            "source_id": 128,
             "feature_display": "KIT"
         },
         {
@@ -12659,6 +13736,9 @@
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 360,
+            "feature_id": 360,
+            "source_id": 129,
             "feature_display": "KIT p.D816V (Missense)"
         },
         {
@@ -12695,6 +13775,9 @@
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 361,
+            "feature_id": 361,
+            "source_id": 129,
             "feature_display": "KIT Exon 17"
         },
         {
@@ -12731,6 +13814,9 @@
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 362,
+            "feature_id": 362,
+            "source_id": 129,
             "feature_display": "KIT"
         },
         {
@@ -12767,6 +13853,9 @@
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 363,
+            "feature_id": 363,
+            "source_id": 129,
             "feature_display": "KIT Exon 11"
         },
         {
@@ -12803,6 +13892,9 @@
             "publication_date": "2016-01-03",
             "last_updated": "2018-09-14",
             "_deprecated": false,
+            "assertion_id": 364,
+            "feature_id": 364,
+            "source_id": 130,
             "feature_display": "KRAS"
         },
         {
@@ -12839,6 +13931,9 @@
             "publication_date": "2015-02-16",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 365,
+            "feature_id": 365,
+            "source_id": 131,
             "feature_display": "KRAS"
         },
         {
@@ -12875,6 +13970,9 @@
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 366,
+            "feature_id": 366,
+            "source_id": 66,
             "feature_display": "KRAS Exon 2"
         },
         {
@@ -12911,6 +14009,9 @@
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 367,
+            "feature_id": 367,
+            "source_id": 66,
             "feature_display": "KRAS Exon 2"
         },
         {
@@ -12947,6 +14048,9 @@
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 368,
+            "feature_id": 368,
+            "source_id": 66,
             "feature_display": "KRAS Exon 3"
         },
         {
@@ -12983,6 +14087,9 @@
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 369,
+            "feature_id": 369,
+            "source_id": 66,
             "feature_display": "KRAS Exon 3"
         },
         {
@@ -13019,6 +14126,9 @@
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 370,
+            "feature_id": 370,
+            "source_id": 66,
             "feature_display": "KRAS Exon 4"
         },
         {
@@ -13055,6 +14165,9 @@
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 371,
+            "feature_id": 371,
+            "source_id": 66,
             "feature_display": "KRAS Exon 4"
         },
         {
@@ -13091,6 +14204,9 @@
             "publication_date": "2021-05-01",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 372,
+            "feature_id": 372,
+            "source_id": 132,
             "feature_display": "KRAS p.G12C (Missense)"
         },
         {
@@ -13127,6 +14243,9 @@
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 373,
+            "feature_id": 373,
+            "source_id": 20,
             "feature_display": "KRAS"
         },
         {
@@ -13163,6 +14282,9 @@
             "publication_date": "2016-03-24",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 374,
+            "feature_id": 374,
+            "source_id": 133,
             "feature_display": "KRAS p.G12D (Missense)"
         },
         {
@@ -13199,6 +14321,9 @@
             "publication_date": "2017-05-25",
             "last_updated": "2019-04-13",
             "_deprecated": false,
+            "assertion_id": 375,
+            "feature_id": 375,
+            "source_id": 134,
             "feature_display": "KRAS p.G12 (Missense)"
         },
         {
@@ -13235,6 +14360,9 @@
             "publication_date": "2017-05-25",
             "last_updated": "2019-04-13",
             "_deprecated": false,
+            "assertion_id": 376,
+            "feature_id": 376,
+            "source_id": 134,
             "feature_display": "KRAS p.G13 (Missense)"
         },
         {
@@ -13271,6 +14399,9 @@
             "publication_date": "2017-05-25",
             "last_updated": "2019-04-13",
             "_deprecated": false,
+            "assertion_id": 377,
+            "feature_id": 377,
+            "source_id": 134,
             "feature_display": "KRAS p.Q61 (Missense)"
         },
         {
@@ -13307,6 +14438,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 378,
+            "feature_id": 378,
+            "source_id": 135,
             "feature_display": "KRAS"
         },
         {
@@ -13343,6 +14477,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 379,
+            "feature_id": 379,
+            "source_id": 135,
             "feature_display": "KRAS"
         },
         {
@@ -13379,6 +14516,9 @@
             "publication_date": "2015-03-12",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 380,
+            "feature_id": 380,
+            "source_id": 136,
             "feature_display": "KRAS"
         },
         {
@@ -13415,6 +14555,9 @@
             "publication_date": "2015-04-09",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 381,
+            "feature_id": 381,
+            "source_id": 54,
             "feature_display": "KRAS"
         },
         {
@@ -13451,6 +14594,9 @@
             "publication_date": "2014-04-03",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 382,
+            "feature_id": 382,
+            "source_id": 137,
             "feature_display": "KRAS"
         },
         {
@@ -13487,6 +14633,9 @@
             "publication_date": "2014-04-03",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 383,
+            "feature_id": 383,
+            "source_id": 137,
             "feature_display": "KRAS"
         },
         {
@@ -13523,6 +14672,9 @@
             "publication_date": "2019-09-13",
             "last_updated": "2019-08-08",
             "_deprecated": false,
+            "assertion_id": 384,
+            "feature_id": 384,
+            "source_id": 138,
             "feature_display": "KRAS"
         },
         {
@@ -13559,6 +14711,9 @@
             "publication_date": "2015-05-11",
             "last_updated": "2019-08-08",
             "_deprecated": false,
+            "assertion_id": 385,
+            "feature_id": 385,
+            "source_id": 139,
             "feature_display": "KRAS"
         },
         {
@@ -13595,6 +14750,9 @@
             "publication_date": "2009-12-1",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 386,
+            "feature_id": 386,
+            "source_id": 71,
             "feature_display": "MAP2K1 p.P124L (Missense)"
         },
         {
@@ -13631,6 +14789,9 @@
             "publication_date": "2009-12-1",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 387,
+            "feature_id": 387,
+            "source_id": 71,
             "feature_display": "MAP2K1 p.Q56P (Missense)"
         },
         {
@@ -13667,6 +14828,9 @@
             "publication_date": "2009-12-1",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 388,
+            "feature_id": 388,
+            "source_id": 71,
             "feature_display": "MAP2K1 p.P124L (Missense)"
         },
         {
@@ -13703,6 +14867,9 @@
             "publication_date": "2015-07-15",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 389,
+            "feature_id": 389,
+            "source_id": 140,
             "feature_display": "MAP2K1 p.Q56P (Missense)"
         },
         {
@@ -13739,6 +14906,9 @@
             "publication_date": "2013-04-08",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 390,
+            "feature_id": 390,
+            "source_id": 141,
             "feature_display": "MAP2K1 p.Q56P (Missense)"
         },
         {
@@ -13775,6 +14945,9 @@
             "publication_date": "2013-04-08",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 391,
+            "feature_id": 391,
+            "source_id": 141,
             "feature_display": "MAP2K1 p.Q56P (Missense)"
         },
         {
@@ -13811,6 +14984,9 @@
             "publication_date": "2011-03-07",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 392,
+            "feature_id": 392,
+            "source_id": 142,
             "feature_display": "MAP2K1 p.C121S (Missense)"
         },
         {
@@ -13847,6 +15023,9 @@
             "publication_date": "2011-03-07",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 393,
+            "feature_id": 393,
+            "source_id": 142,
             "feature_display": "MAP2K1 p.C121S (Missense)"
         },
         {
@@ -13883,6 +15062,9 @@
             "publication_date": "2014-01-07",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 394,
+            "feature_id": 394,
+            "source_id": 78,
             "feature_display": "MAP2K2 p.Q60P (Missense)"
         },
         {
@@ -13919,6 +15101,9 @@
             "publication_date": "2015-03-05",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 395,
+            "feature_id": 395,
+            "source_id": 143,
             "feature_display": "MAPK1 p.E322K (Missense)"
         },
         {
@@ -13955,6 +15140,9 @@
             "publication_date": "2016-08-19",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 396,
+            "feature_id": 396,
+            "source_id": 144,
             "feature_display": "MC1R"
         },
         {
@@ -13991,6 +15179,9 @@
             "publication_date": "2009-03-17",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 397,
+            "feature_id": 397,
+            "source_id": 145,
             "feature_display": "MET p.T1010I (Missense)"
         },
         {
@@ -14027,6 +15218,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 398,
+            "feature_id": 398,
+            "source_id": 11,
             "feature_display": "MET Exon 14 (Splice Site)"
         },
         {
@@ -14063,6 +15257,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 399,
+            "feature_id": 399,
+            "source_id": 11,
             "feature_display": "MET Exon 14 (Deletion)"
         },
         {
@@ -14099,6 +15296,9 @@
             "publication_date": "2022-08-10",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 400,
+            "feature_id": 400,
+            "source_id": 146,
             "feature_display": "MET Exon 14 (Splice Site)"
         },
         {
@@ -14135,6 +15335,9 @@
             "publication_date": "2022-08-10",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 401,
+            "feature_id": 401,
+            "source_id": 146,
             "feature_display": "MET Exon 14 (Deletion)"
         },
         {
@@ -14171,6 +15374,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 402,
+            "feature_id": 402,
+            "source_id": 147,
             "feature_display": "MLH3"
         },
         {
@@ -14207,6 +15413,9 @@
             "publication_date": "2011-10-18",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 403,
+            "feature_id": 403,
+            "source_id": 148,
             "feature_display": "MPL p.W515L (Missense)"
         },
         {
@@ -14243,6 +15452,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 404,
+            "feature_id": 404,
+            "source_id": 147,
             "feature_display": "MSH2"
         },
         {
@@ -14279,6 +15491,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 405,
+            "feature_id": 405,
+            "source_id": 147,
             "feature_display": "MSH6"
         },
         {
@@ -14315,6 +15530,9 @@
             "publication_date": "2019-01-15",
             "last_updated": "2019-08-12",
             "_deprecated": false,
+            "assertion_id": 406,
+            "feature_id": 406,
+            "source_id": 149,
             "feature_display": "MTOR"
         },
         {
@@ -14351,6 +15569,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 407,
+            "feature_id": 407,
+            "source_id": 147,
             "feature_display": "MYH"
         },
         {
@@ -14387,6 +15608,9 @@
             "publication_date": "2013-10-14",
             "last_updated": "2019-03-25",
             "_deprecated": false,
+            "assertion_id": 408,
+            "feature_id": 408,
+            "source_id": 150,
             "feature_display": "NFE2L2 (Activating mutation)"
         },
         {
@@ -14423,6 +15647,9 @@
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 409,
+            "feature_id": 409,
+            "source_id": 66,
             "feature_display": "NRAS"
         },
         {
@@ -14459,6 +15686,9 @@
             "publication_date": "2018-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 410,
+            "feature_id": 410,
+            "source_id": 66,
             "feature_display": "NRAS"
         },
         {
@@ -14495,6 +15725,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 411,
+            "feature_id": 411,
+            "source_id": 33,
             "feature_display": "NRAS p.G12A (Missense)"
         },
         {
@@ -14531,6 +15764,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 412,
+            "feature_id": 412,
+            "source_id": 33,
             "feature_display": "NRAS p.G12C (Missense)"
         },
         {
@@ -14567,6 +15803,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 413,
+            "feature_id": 413,
+            "source_id": 33,
             "feature_display": "NRAS p.G12D (Missense)"
         },
         {
@@ -14603,6 +15842,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 414,
+            "feature_id": 414,
+            "source_id": 33,
             "feature_display": "NRAS p.G12R (Missense)"
         },
         {
@@ -14639,6 +15881,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 415,
+            "feature_id": 415,
+            "source_id": 33,
             "feature_display": "NRAS p.G12S (Missense)"
         },
         {
@@ -14675,6 +15920,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 416,
+            "feature_id": 416,
+            "source_id": 33,
             "feature_display": "NRAS p.G12V (Missense)"
         },
         {
@@ -14711,6 +15959,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 417,
+            "feature_id": 417,
+            "source_id": 33,
             "feature_display": "NRAS p.G13A (Missense)"
         },
         {
@@ -14747,6 +15998,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 418,
+            "feature_id": 418,
+            "source_id": 33,
             "feature_display": "NRAS p.G13D (Missense)"
         },
         {
@@ -14783,6 +16037,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 419,
+            "feature_id": 419,
+            "source_id": 33,
             "feature_display": "NRAS p.G13R (Missense)"
         },
         {
@@ -14819,6 +16076,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 420,
+            "feature_id": 420,
+            "source_id": 33,
             "feature_display": "NRAS p.G13V (Missense)"
         },
         {
@@ -14855,6 +16115,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 421,
+            "feature_id": 421,
+            "source_id": 33,
             "feature_display": "NRAS p.Q61E (Missense)"
         },
         {
@@ -14891,6 +16154,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 422,
+            "feature_id": 422,
+            "source_id": 33,
             "feature_display": "NRAS p.Q61H (Missense)"
         },
         {
@@ -14927,6 +16193,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 423,
+            "feature_id": 423,
+            "source_id": 33,
             "feature_display": "NRAS p.Q61L (Missense)"
         },
         {
@@ -14963,6 +16232,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 424,
+            "feature_id": 424,
+            "source_id": 33,
             "feature_display": "NRAS p.Q61P (Missense)"
         },
         {
@@ -14999,6 +16271,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 425,
+            "feature_id": 425,
+            "source_id": 151,
             "feature_display": "NRAS p.Q61R (Missense)"
         },
         {
@@ -15035,6 +16310,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 426,
+            "feature_id": 426,
+            "source_id": 151,
             "feature_display": "NRAS p.G12C (Missense)"
         },
         {
@@ -15071,6 +16349,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 427,
+            "feature_id": 427,
+            "source_id": 151,
             "feature_display": "NRAS p.G12D (Missense)"
         },
         {
@@ -15107,6 +16388,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 428,
+            "feature_id": 428,
+            "source_id": 151,
             "feature_display": "NRAS p.G12R (Missense)"
         },
         {
@@ -15143,6 +16427,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 429,
+            "feature_id": 429,
+            "source_id": 151,
             "feature_display": "NRAS p.G12S (Missense)"
         },
         {
@@ -15179,6 +16466,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 430,
+            "feature_id": 430,
+            "source_id": 151,
             "feature_display": "NRAS p.G12V (Missense)"
         },
         {
@@ -15215,6 +16505,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 431,
+            "feature_id": 431,
+            "source_id": 151,
             "feature_display": "NRAS p.G13A (Missense)"
         },
         {
@@ -15251,6 +16544,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 432,
+            "feature_id": 432,
+            "source_id": 151,
             "feature_display": "NRAS p.G13D (Missense)"
         },
         {
@@ -15287,6 +16583,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 433,
+            "feature_id": 433,
+            "source_id": 151,
             "feature_display": "NRAS p.G13R (Missense)"
         },
         {
@@ -15323,6 +16622,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 434,
+            "feature_id": 434,
+            "source_id": 151,
             "feature_display": "NRAS p.G13V (Missense)"
         },
         {
@@ -15359,6 +16661,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 435,
+            "feature_id": 435,
+            "source_id": 151,
             "feature_display": "NRAS p.Q61E (Missense)"
         },
         {
@@ -15395,6 +16700,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 436,
+            "feature_id": 436,
+            "source_id": 151,
             "feature_display": "NRAS p.Q61H (Missense)"
         },
         {
@@ -15431,6 +16739,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 437,
+            "feature_id": 437,
+            "source_id": 151,
             "feature_display": "NRAS p.Q61L (Missense)"
         },
         {
@@ -15467,6 +16778,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 438,
+            "feature_id": 438,
+            "source_id": 151,
             "feature_display": "NRAS p.Q61P (Missense)"
         },
         {
@@ -15503,6 +16817,9 @@
             "publication_date": "2016-09-21",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 439,
+            "feature_id": 439,
+            "source_id": 151,
             "feature_display": "NRAS p.Q61R (Missense)"
         },
         {
@@ -15539,6 +16856,9 @@
             "publication_date": "2011-12-16",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 440,
+            "feature_id": 440,
+            "source_id": 152,
             "feature_display": "NRAS"
         },
         {
@@ -15575,6 +16895,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 441,
+            "feature_id": 441,
+            "source_id": 59,
             "feature_display": "PALB2"
         },
         {
@@ -15611,6 +16934,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 442,
+            "feature_id": 442,
+            "source_id": 59,
             "feature_display": "PALB2"
         },
         {
@@ -15647,6 +16973,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 443,
+            "feature_id": 443,
+            "source_id": 59,
             "feature_display": "PALB2"
         },
         {
@@ -15683,6 +17012,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 444,
+            "feature_id": 444,
+            "source_id": 59,
             "feature_display": "PALB2"
         },
         {
@@ -15719,6 +17051,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 445,
+            "feature_id": 445,
+            "source_id": 59,
             "feature_display": "PALB2"
         },
         {
@@ -15755,6 +17090,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 446,
+            "feature_id": 446,
+            "source_id": 59,
             "feature_display": "PALB2"
         },
         {
@@ -15791,6 +17129,9 @@
             "publication_date": "2015-02-25",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 447,
+            "feature_id": 447,
+            "source_id": 85,
             "feature_display": "PALB2"
         },
         {
@@ -15827,6 +17168,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 448,
+            "feature_id": 448,
+            "source_id": 58,
             "feature_display": "PALB2"
         },
         {
@@ -15863,6 +17207,9 @@
             "publication_date": "2018-01-04",
             "last_updated": "2018-09-11",
             "_deprecated": false,
+            "assertion_id": 449,
+            "feature_id": 449,
+            "source_id": 153,
             "feature_display": "PBRM1 (Nonsense)"
         },
         {
@@ -15899,6 +17246,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 450,
+            "feature_id": 450,
+            "source_id": 127,
             "feature_display": "PDGFRA"
         },
         {
@@ -15935,6 +17285,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 451,
+            "feature_id": 451,
+            "source_id": 127,
             "feature_display": "PDGFRA p.D842V (Missense)"
         },
         {
@@ -15971,6 +17324,9 @@
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 452,
+            "feature_id": 452,
+            "source_id": 129,
             "feature_display": "PDGFRA p.D842V (Missense)"
         },
         {
@@ -16007,6 +17363,9 @@
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 453,
+            "feature_id": 453,
+            "source_id": 129,
             "feature_display": "PDGFRA Exon 18"
         },
         {
@@ -16043,6 +17402,9 @@
             "publication_date": "2023-06-01",
             "last_updated": "2021-09-02",
             "_deprecated": false,
+            "assertion_id": 454,
+            "feature_id": 454,
+            "source_id": 129,
             "feature_display": "PDGFRA p.D842V (Missense)"
         },
         {
@@ -16079,6 +17441,9 @@
             "publication_date": "2018-01-04",
             "last_updated": "2018-09-11",
             "_deprecated": false,
+            "assertion_id": 455,
+            "feature_id": 455,
+            "source_id": 153,
             "feature_display": "PBRM1 (Frameshift)"
         },
         {
@@ -16115,6 +17480,9 @@
             "publication_date": "2020-09-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 456,
+            "feature_id": 456,
+            "source_id": 154,
             "feature_display": "PIK3CA"
         },
         {
@@ -16151,6 +17519,9 @@
             "publication_date": "2013-10-01",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 457,
+            "feature_id": 457,
+            "source_id": 155,
             "feature_display": "PIK3CA"
         },
         {
@@ -16187,6 +17558,9 @@
             "publication_date": "2017-12-20",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 458,
+            "feature_id": 458,
+            "source_id": 44,
             "feature_display": "PIK3CA"
         },
         {
@@ -16223,6 +17597,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 459,
+            "feature_id": 459,
+            "source_id": 60,
             "feature_display": "PIK3CA p.E545Q (Missense)"
         },
         {
@@ -16259,6 +17636,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 460,
+            "feature_id": 460,
+            "source_id": 60,
             "feature_display": "PIK3CA p.C420R (Missense)"
         },
         {
@@ -16295,6 +17675,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 461,
+            "feature_id": 461,
+            "source_id": 60,
             "feature_display": "PIK3CA p.E542K (Missense)"
         },
         {
@@ -16331,6 +17714,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 462,
+            "feature_id": 462,
+            "source_id": 60,
             "feature_display": "PIK3CA p.E542Q (Missense)"
         },
         {
@@ -16367,6 +17753,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 463,
+            "feature_id": 463,
+            "source_id": 60,
             "feature_display": "PIK3CA p.E545A (Missense)"
         },
         {
@@ -16403,6 +17792,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 464,
+            "feature_id": 464,
+            "source_id": 60,
             "feature_display": "PIK3CA p.E545D (Missense)"
         },
         {
@@ -16439,6 +17831,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 465,
+            "feature_id": 465,
+            "source_id": 60,
             "feature_display": "PIK3CA p.E545D (Missense)"
         },
         {
@@ -16475,6 +17870,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 466,
+            "feature_id": 466,
+            "source_id": 60,
             "feature_display": "PIK3CA p.E545G (Missense)"
         },
         {
@@ -16511,6 +17909,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 467,
+            "feature_id": 467,
+            "source_id": 60,
             "feature_display": "PIK3CA p.E545K (Missense)"
         },
         {
@@ -16547,6 +17948,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 468,
+            "feature_id": 468,
+            "source_id": 60,
             "feature_display": "PIK3CA p.G1049R (Missense)"
         },
         {
@@ -16583,6 +17987,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 469,
+            "feature_id": 469,
+            "source_id": 60,
             "feature_display": "PIK3CA p.G1049S (Missense)"
         },
         {
@@ -16619,6 +18026,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 470,
+            "feature_id": 470,
+            "source_id": 60,
             "feature_display": "PIK3CA p.H1047L (Missense)"
         },
         {
@@ -16655,6 +18065,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 471,
+            "feature_id": 471,
+            "source_id": 60,
             "feature_display": "PIK3CA p.H1047R (Missense)"
         },
         {
@@ -16691,6 +18104,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 472,
+            "feature_id": 472,
+            "source_id": 60,
             "feature_display": "PIK3CA p.H1047Y (Missense)"
         },
         {
@@ -16727,6 +18143,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 473,
+            "feature_id": 473,
+            "source_id": 60,
             "feature_display": "PIK3CA p.H701P (Missense)"
         },
         {
@@ -16763,6 +18182,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 474,
+            "feature_id": 474,
+            "source_id": 60,
             "feature_display": "PIK3CA p.M1043I (Missense)"
         },
         {
@@ -16799,6 +18221,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 475,
+            "feature_id": 475,
+            "source_id": 60,
             "feature_display": "PIK3CA p.M1043I (Missense)"
         },
         {
@@ -16835,6 +18260,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 476,
+            "feature_id": 476,
+            "source_id": 60,
             "feature_display": "PIK3CA p.P539R (Missense)"
         },
         {
@@ -16871,6 +18299,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 477,
+            "feature_id": 477,
+            "source_id": 60,
             "feature_display": "PIK3CA p.Q546K (Missense)"
         },
         {
@@ -16907,6 +18338,9 @@
             "publication_date": "2010-07-14",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 478,
+            "feature_id": 478,
+            "source_id": 60,
             "feature_display": "PIK3CA p.Y1021C (Missense)"
         },
         {
@@ -16943,6 +18377,9 @@
             "publication_date": "2015-07-02",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 479,
+            "feature_id": 479,
+            "source_id": 156,
             "feature_display": "POLD1 p.D316H (Missense)"
         },
         {
@@ -16979,6 +18416,9 @@
             "publication_date": "2015-07-02",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 480,
+            "feature_id": 480,
+            "source_id": 156,
             "feature_display": "POLD1 p.D316G (Missense)"
         },
         {
@@ -17015,6 +18455,9 @@
             "publication_date": "2015-07-02",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 481,
+            "feature_id": 481,
+            "source_id": 156,
             "feature_display": "POLD1 p.R409W (Missense)"
         },
         {
@@ -17051,6 +18494,9 @@
             "publication_date": "2015-07-02",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 482,
+            "feature_id": 482,
+            "source_id": 156,
             "feature_display": "POLD1 p.L474P (Missense)"
         },
         {
@@ -17087,6 +18533,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 483,
+            "feature_id": 483,
+            "source_id": 147,
             "feature_display": "POLD1"
         },
         {
@@ -17123,6 +18572,9 @@
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 484,
+            "feature_id": 484,
+            "source_id": 157,
             "feature_display": "POLD1"
         },
         {
@@ -17159,6 +18611,9 @@
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 485,
+            "feature_id": 485,
+            "source_id": 157,
             "feature_display": "POLD1"
         },
         {
@@ -17195,6 +18650,9 @@
             "publication_date": "2015-07-02",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 486,
+            "feature_id": 486,
+            "source_id": 156,
             "feature_display": "POLE p.L424V (Missense)"
         },
         {
@@ -17231,6 +18689,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 487,
+            "feature_id": 487,
+            "source_id": 147,
             "feature_display": "POLE"
         },
         {
@@ -17267,6 +18728,9 @@
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 488,
+            "feature_id": 488,
+            "source_id": 157,
             "feature_display": "POLE"
         },
         {
@@ -17303,6 +18767,9 @@
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 489,
+            "feature_id": 489,
+            "source_id": 157,
             "feature_display": "POLE"
         },
         {
@@ -17339,6 +18806,9 @@
             "publication_date": "2014-12-16",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 490,
+            "feature_id": 490,
+            "source_id": 158,
             "feature_display": "PTEN (Nonsense)"
         },
         {
@@ -17375,6 +18845,9 @@
             "publication_date": "2014-12-16",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 491,
+            "feature_id": 491,
+            "source_id": 158,
             "feature_display": "PTEN (Frameshift)"
         },
         {
@@ -17411,6 +18884,9 @@
             "publication_date": "2014-12-16",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 492,
+            "feature_id": 492,
+            "source_id": 158,
             "feature_display": "PTEN (Splice Site)"
         },
         {
@@ -17447,6 +18923,9 @@
             "publication_date": "2017-02-21",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 493,
+            "feature_id": 493,
+            "source_id": 159,
             "feature_display": "PTEN (Nonsense)"
         },
         {
@@ -17483,6 +18962,9 @@
             "publication_date": "2017-02-21",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 494,
+            "feature_id": 494,
+            "source_id": 159,
             "feature_display": "PTEN (Frameshift)"
         },
         {
@@ -17519,6 +19001,9 @@
             "publication_date": "2017-02-21",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 495,
+            "feature_id": 495,
+            "source_id": 159,
             "feature_display": "PTEN (Splice Site)"
         },
         {
@@ -17555,6 +19040,9 @@
             "publication_date": "2017-12-20",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 496,
+            "feature_id": 496,
+            "source_id": 44,
             "feature_display": "PTEN"
         },
         {
@@ -17591,6 +19079,9 @@
             "publication_date": "2016-02-04",
             "last_updated": "2018-09-14",
             "_deprecated": false,
+            "assertion_id": 497,
+            "feature_id": 497,
+            "source_id": 160,
             "feature_display": "PTEN (Nonsense)"
         },
         {
@@ -17627,6 +19118,9 @@
             "publication_date": "2016-02-04",
             "last_updated": "2018-09-14",
             "_deprecated": false,
+            "assertion_id": 498,
+            "feature_id": 498,
+            "source_id": 160,
             "feature_display": "PTEN (Frameshift)"
         },
         {
@@ -17663,6 +19157,9 @@
             "publication_date": "2016-02-04",
             "last_updated": "2018-09-14",
             "_deprecated": false,
+            "assertion_id": 499,
+            "feature_id": 499,
+            "source_id": 160,
             "feature_display": "PTEN (Splice Site)"
         },
         {
@@ -17699,6 +19196,9 @@
             "publication_date": "2016-02-04",
             "last_updated": "2018-09-14",
             "_deprecated": false,
+            "assertion_id": 500,
+            "feature_id": 500,
+            "source_id": 160,
             "feature_display": "PTEN (Nonsense)"
         },
         {
@@ -17735,6 +19235,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 501,
+            "feature_id": 501,
+            "source_id": 33,
             "feature_display": "PTPN11"
         },
         {
@@ -17771,6 +19274,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 502,
+            "feature_id": 502,
+            "source_id": 58,
             "feature_display": "RAD51B"
         },
         {
@@ -17807,6 +19313,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 503,
+            "feature_id": 503,
+            "source_id": 59,
             "feature_display": "RAD51C"
         },
         {
@@ -17843,6 +19352,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 504,
+            "feature_id": 504,
+            "source_id": 59,
             "feature_display": "RAD51C"
         },
         {
@@ -17879,6 +19391,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 505,
+            "feature_id": 505,
+            "source_id": 59,
             "feature_display": "RAD51C"
         },
         {
@@ -17915,6 +19430,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 506,
+            "feature_id": 506,
+            "source_id": 59,
             "feature_display": "RAD51C"
         },
         {
@@ -17951,6 +19469,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 507,
+            "feature_id": 507,
+            "source_id": 59,
             "feature_display": "RAD51C"
         },
         {
@@ -17987,6 +19508,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 508,
+            "feature_id": 508,
+            "source_id": 59,
             "feature_display": "RAD51C"
         },
         {
@@ -18023,6 +19547,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 509,
+            "feature_id": 509,
+            "source_id": 58,
             "feature_display": "RAD51C"
         },
         {
@@ -18059,6 +19586,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 510,
+            "feature_id": 510,
+            "source_id": 59,
             "feature_display": "RAD51D"
         },
         {
@@ -18095,6 +19625,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 511,
+            "feature_id": 511,
+            "source_id": 59,
             "feature_display": "RAD51D"
         },
         {
@@ -18131,6 +19664,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 512,
+            "feature_id": 512,
+            "source_id": 59,
             "feature_display": "RAD51D"
         },
         {
@@ -18167,6 +19703,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 513,
+            "feature_id": 513,
+            "source_id": 59,
             "feature_display": "RAD51D"
         },
         {
@@ -18203,6 +19742,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 514,
+            "feature_id": 514,
+            "source_id": 59,
             "feature_display": "RAD51D"
         },
         {
@@ -18239,6 +19781,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 515,
+            "feature_id": 515,
+            "source_id": 59,
             "feature_display": "RAD51D"
         },
         {
@@ -18275,6 +19820,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 516,
+            "feature_id": 516,
+            "source_id": 58,
             "feature_display": "RAD51D"
         },
         {
@@ -18311,6 +19859,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 517,
+            "feature_id": 517,
+            "source_id": 58,
             "feature_display": "RAD54L"
         },
         {
@@ -18347,6 +19898,9 @@
             "publication_date": "2015-04-09",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 518,
+            "feature_id": 518,
+            "source_id": 54,
             "feature_display": "RBM10"
         },
         {
@@ -18383,6 +19937,9 @@
             "publication_date": "2018-08-01",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 519,
+            "feature_id": 519,
+            "source_id": 161,
             "feature_display": "RET p.V804M (Missense)"
         },
         {
@@ -18419,6 +19976,9 @@
             "publication_date": "2018-08-01",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 520,
+            "feature_id": 520,
+            "source_id": 161,
             "feature_display": "RET p.M918T (Missense)"
         },
         {
@@ -18455,6 +20015,9 @@
             "publication_date": "2024-09-27",
             "last_updated": "2024-10-02",
             "_deprecated": false,
+            "assertion_id": 521,
+            "feature_id": 521,
+            "source_id": 162,
             "feature_display": "RET"
         },
         {
@@ -18491,6 +20054,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 522,
+            "feature_id": 522,
+            "source_id": 33,
             "feature_display": "RUNX1 (Nonsense)"
         },
         {
@@ -18527,6 +20093,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 523,
+            "feature_id": 523,
+            "source_id": 33,
             "feature_display": "RUNX1 (Frameshift)"
         },
         {
@@ -18563,6 +20132,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 524,
+            "feature_id": 524,
+            "source_id": 33,
             "feature_display": "SETBP1 p.E858K (Missense)"
         },
         {
@@ -18599,6 +20171,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 525,
+            "feature_id": 525,
+            "source_id": 33,
             "feature_display": "SETBP1 p.T864M (Missense)"
         },
         {
@@ -18635,6 +20210,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 526,
+            "feature_id": 526,
+            "source_id": 33,
             "feature_display": "SETBP1 p.I865N (Missense)"
         },
         {
@@ -18671,6 +20249,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 527,
+            "feature_id": 527,
+            "source_id": 33,
             "feature_display": "SETBP1 p.D868N (Missense)"
         },
         {
@@ -18707,6 +20288,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 528,
+            "feature_id": 528,
+            "source_id": 33,
             "feature_display": "SETBP1 p.D868Y (Missense)"
         },
         {
@@ -18743,6 +20327,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 529,
+            "feature_id": 529,
+            "source_id": 33,
             "feature_display": "SETBP1 p.S869C (Missense)"
         },
         {
@@ -18779,6 +20366,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 530,
+            "feature_id": 530,
+            "source_id": 33,
             "feature_display": "SETBP1 p.G870S (Missense)"
         },
         {
@@ -18815,6 +20405,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 531,
+            "feature_id": 531,
+            "source_id": 33,
             "feature_display": "SF3B1 p.E622Q (Missense)"
         },
         {
@@ -18851,6 +20444,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 532,
+            "feature_id": 532,
+            "source_id": 33,
             "feature_display": "SF3B1 p.E622D (Missense)"
         },
         {
@@ -18887,6 +20483,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 533,
+            "feature_id": 533,
+            "source_id": 33,
             "feature_display": "SF3B1 p.Y623C (Missense)"
         },
         {
@@ -18923,6 +20522,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 534,
+            "feature_id": 534,
+            "source_id": 33,
             "feature_display": "SF3B1 p.R625C (Missense)"
         },
         {
@@ -18959,6 +20561,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 535,
+            "feature_id": 535,
+            "source_id": 33,
             "feature_display": "SF3B1 p.R625H (Missense)"
         },
         {
@@ -18995,6 +20600,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 536,
+            "feature_id": 536,
+            "source_id": 33,
             "feature_display": "SF3B1 p.N626H (Missense)"
         },
         {
@@ -19031,6 +20639,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 537,
+            "feature_id": 537,
+            "source_id": 33,
             "feature_display": "SF3B1 p.N626Y (Missense)"
         },
         {
@@ -19067,6 +20678,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 538,
+            "feature_id": 538,
+            "source_id": 33,
             "feature_display": "SF3B1 p.N626D (Missense)"
         },
         {
@@ -19103,6 +20717,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 539,
+            "feature_id": 539,
+            "source_id": 33,
             "feature_display": "SF3B1 p.H662R (Missense)"
         },
         {
@@ -19139,6 +20756,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 540,
+            "feature_id": 540,
+            "source_id": 33,
             "feature_display": "SF3B1 p.T663P (Missense)"
         },
         {
@@ -19175,6 +20795,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 541,
+            "feature_id": 541,
+            "source_id": 33,
             "feature_display": "SF3B1 p.K666N (Missense)"
         },
         {
@@ -19211,6 +20834,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 542,
+            "feature_id": 542,
+            "source_id": 33,
             "feature_display": "SF3B1 p.K666T (Missense)"
         },
         {
@@ -19247,6 +20873,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 543,
+            "feature_id": 543,
+            "source_id": 33,
             "feature_display": "SF3B1 p.K666E (Missense)"
         },
         {
@@ -19283,6 +20912,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 544,
+            "feature_id": 544,
+            "source_id": 33,
             "feature_display": "SF3B1 p.K700E (Missense)"
         },
         {
@@ -19319,6 +20951,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 545,
+            "feature_id": 545,
+            "source_id": 33,
             "feature_display": "SF3B1 p.I704S (Missense)"
         },
         {
@@ -19355,6 +20990,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 546,
+            "feature_id": 546,
+            "source_id": 33,
             "feature_display": "SF3B1 p.G740E (Missense)"
         },
         {
@@ -19391,6 +21029,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 547,
+            "feature_id": 547,
+            "source_id": 33,
             "feature_display": "SF3B1 p.G740V (Missense)"
         },
         {
@@ -19427,6 +21068,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 548,
+            "feature_id": 548,
+            "source_id": 33,
             "feature_display": "SF3B1 p.G742D (Missense)"
         },
         {
@@ -19463,6 +21107,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 549,
+            "feature_id": 549,
+            "source_id": 33,
             "feature_display": "SF3B1 p.D781E (Missense)"
         },
         {
@@ -19499,6 +21146,9 @@
             "publication_date": "2017-01-19",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 550,
+            "feature_id": 550,
+            "source_id": 163,
             "feature_display": "SMARCA4 (Nonsense)"
         },
         {
@@ -19535,6 +21185,9 @@
             "publication_date": "2017-01-19",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 551,
+            "feature_id": 551,
+            "source_id": 163,
             "feature_display": "SMARCA4 (Frameshift)"
         },
         {
@@ -19571,6 +21224,9 @@
             "publication_date": "2017-01-19",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 552,
+            "feature_id": 552,
+            "source_id": 163,
             "feature_display": "SMARCA4 (Splice Site)"
         },
         {
@@ -19607,6 +21263,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2022-10-06",
             "_deprecated": false,
+            "assertion_id": 553,
+            "feature_id": 553,
+            "source_id": 164,
             "feature_display": "SPOP (Missense)"
         },
         {
@@ -19643,6 +21302,9 @@
             "publication_date": "2018-11-15",
             "last_updated": "2021-11-03",
             "_deprecated": false,
+            "assertion_id": 554,
+            "feature_id": 554,
+            "source_id": 165,
             "feature_display": "SPOP (Missense)"
         },
         {
@@ -19679,6 +21341,9 @@
             "publication_date": "2021-09-07",
             "last_updated": "2021-11-03",
             "_deprecated": false,
+            "assertion_id": 555,
+            "feature_id": 555,
+            "source_id": 166,
             "feature_display": "SPOP (Missense)"
         },
         {
@@ -19715,6 +21380,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 556,
+            "feature_id": 556,
+            "source_id": 33,
             "feature_display": "STAG2 (Nonsense)"
         },
         {
@@ -19751,6 +21419,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 557,
+            "feature_id": 557,
+            "source_id": 33,
             "feature_display": "STAG2 (Frameshift)"
         },
         {
@@ -19787,6 +21458,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 558,
+            "feature_id": 558,
+            "source_id": 33,
             "feature_display": "STAG2 (Splice Site)"
         },
         {
@@ -19823,6 +21497,9 @@
             "publication_date": "2011-04-15",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 559,
+            "feature_id": 559,
+            "source_id": 167,
             "feature_display": "TET2"
         },
         {
@@ -19859,6 +21536,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 560,
+            "feature_id": 560,
+            "source_id": 33,
             "feature_display": "TP53 (Missense)"
         },
         {
@@ -19895,6 +21575,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 561,
+            "feature_id": 561,
+            "source_id": 33,
             "feature_display": "TP53 (Nonsense)"
         },
         {
@@ -19931,6 +21614,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 562,
+            "feature_id": 562,
+            "source_id": 33,
             "feature_display": "TP53 (Frameshift)"
         },
         {
@@ -19967,6 +21653,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 563,
+            "feature_id": 563,
+            "source_id": 33,
             "feature_display": "TP53 (Splice Site)"
         },
         {
@@ -20003,6 +21692,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 564,
+            "feature_id": 564,
+            "source_id": 33,
             "feature_display": "TP53 (Nonsense)"
         },
         {
@@ -20039,6 +21731,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 565,
+            "feature_id": 565,
+            "source_id": 33,
             "feature_display": "TP53 (Frameshift)"
         },
         {
@@ -20075,6 +21770,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 566,
+            "feature_id": 566,
+            "source_id": 33,
             "feature_display": "TP53 (Splice Site)"
         },
         {
@@ -20111,6 +21809,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 567,
+            "feature_id": 567,
+            "source_id": 33,
             "feature_display": "TP53 (Missense)"
         },
         {
@@ -20147,6 +21848,9 @@
             "publication_date": "2010-12-07",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 568,
+            "feature_id": 568,
+            "source_id": 168,
             "feature_display": "TP53"
         },
         {
@@ -20183,6 +21887,9 @@
             "publication_date": "2017-12-20",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 569,
+            "feature_id": 569,
+            "source_id": 44,
             "feature_display": "TP53"
         },
         {
@@ -20219,6 +21926,9 @@
             "publication_date": "2019-09-13",
             "last_updated": "2019-08-08",
             "_deprecated": false,
+            "assertion_id": 570,
+            "feature_id": 570,
+            "source_id": 138,
             "feature_display": "TP53"
         },
         {
@@ -20255,6 +21965,9 @@
             "publication_date": "2020-02-01",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 571,
+            "feature_id": 571,
+            "source_id": 169,
             "feature_display": "TSC1"
         },
         {
@@ -20291,6 +22004,9 @@
             "publication_date": "2012-08-23",
             "last_updated": "2018-09-19",
             "_deprecated": false,
+            "assertion_id": 572,
+            "feature_id": 572,
+            "source_id": 110,
             "feature_display": "TSC1 (Nonsense)"
         },
         {
@@ -20327,6 +22043,9 @@
             "publication_date": "2012-08-23",
             "last_updated": "2018-09-19",
             "_deprecated": false,
+            "assertion_id": 573,
+            "feature_id": 573,
+            "source_id": 110,
             "feature_display": "TSC1 (Frameshift)"
         },
         {
@@ -20363,6 +22082,9 @@
             "publication_date": "2014-10-09",
             "last_updated": "2018-09-19",
             "_deprecated": false,
+            "assertion_id": 574,
+            "feature_id": 574,
+            "source_id": 111,
             "feature_display": "TSC1 (Nonsense)"
         },
         {
@@ -20399,6 +22121,9 @@
             "publication_date": "2014-10-09",
             "last_updated": "2018-09-19",
             "_deprecated": false,
+            "assertion_id": 575,
+            "feature_id": 575,
+            "source_id": 111,
             "feature_display": "TSC1 (Frameshift)"
         },
         {
@@ -20435,6 +22160,9 @@
             "publication_date": "2019-01-15",
             "last_updated": "2019-08-12",
             "_deprecated": false,
+            "assertion_id": 576,
+            "feature_id": 576,
+            "source_id": 149,
             "feature_display": "TSC1"
         },
         {
@@ -20471,6 +22199,9 @@
             "publication_date": "2019-01-15",
             "last_updated": "2019-08-12",
             "_deprecated": false,
+            "assertion_id": 577,
+            "feature_id": 577,
+            "source_id": 149,
             "feature_display": "TSC2"
         },
         {
@@ -20507,6 +22238,9 @@
             "publication_date": "2020-02-01",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 578,
+            "feature_id": 578,
+            "source_id": 169,
             "feature_display": "TSC2"
         },
         {
@@ -20543,6 +22277,9 @@
             "publication_date": "2012-08-23",
             "last_updated": "2018-09-19",
             "_deprecated": false,
+            "assertion_id": 579,
+            "feature_id": 579,
+            "source_id": 110,
             "feature_display": "TSC2 (Nonsense)"
         },
         {
@@ -20579,6 +22316,9 @@
             "publication_date": "2012-08-23",
             "last_updated": "2018-09-19",
             "_deprecated": false,
+            "assertion_id": 580,
+            "feature_id": 580,
+            "source_id": 110,
             "feature_display": "TSC2 (Frameshift)"
         },
         {
@@ -20615,6 +22355,9 @@
             "publication_date": "2014-10-09",
             "last_updated": "2018-09-19",
             "_deprecated": false,
+            "assertion_id": 581,
+            "feature_id": 581,
+            "source_id": 111,
             "feature_display": "TSC2 (Nonsense)"
         },
         {
@@ -20651,6 +22394,9 @@
             "publication_date": "2014-10-09",
             "last_updated": "2018-09-19",
             "_deprecated": false,
+            "assertion_id": 582,
+            "feature_id": 582,
+            "source_id": 111,
             "feature_display": "TSC2 (Frameshift)"
         },
         {
@@ -20687,6 +22433,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 583,
+            "feature_id": 583,
+            "source_id": 33,
             "feature_display": "ZRSR2 (Nonsense)"
         },
         {
@@ -20723,6 +22472,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 584,
+            "feature_id": 584,
+            "source_id": 33,
             "feature_display": "ZRSR2 (Frameshift)"
         },
         {
@@ -20761,6 +22513,9 @@
             "publication_date": "2009-08-01",
             "last_updated": "2019-09-12",
             "_deprecated": false,
+            "assertion_id": 585,
+            "feature_id": 585,
+            "source_id": 170,
             "feature_display": "ATM"
         },
         {
@@ -20799,6 +22554,9 @@
             "publication_date": "2018-02-22",
             "last_updated": "2019-04-16",
             "_deprecated": false,
+            "assertion_id": 586,
+            "feature_id": 586,
+            "source_id": 171,
             "feature_display": "ATM (Pathogenic)"
         },
         {
@@ -20837,6 +22595,9 @@
             "publication_date": "2017-04-01",
             "last_updated": "2019-08-15",
             "_deprecated": false,
+            "assertion_id": 587,
+            "feature_id": 587,
+            "source_id": 57,
             "feature_display": "ATM (Pathogenic)"
         },
         {
@@ -20875,6 +22636,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 588,
+            "feature_id": 588,
+            "source_id": 59,
             "feature_display": "BARD1"
         },
         {
@@ -20913,6 +22677,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 589,
+            "feature_id": 589,
+            "source_id": 59,
             "feature_display": "BARD1"
         },
         {
@@ -20951,6 +22718,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 590,
+            "feature_id": 590,
+            "source_id": 59,
             "feature_display": "BARD1"
         },
         {
@@ -20989,6 +22759,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 591,
+            "feature_id": 591,
+            "source_id": 59,
             "feature_display": "BARD1"
         },
         {
@@ -21027,6 +22800,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 592,
+            "feature_id": 592,
+            "source_id": 59,
             "feature_display": "BARD1"
         },
         {
@@ -21065,6 +22841,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 593,
+            "feature_id": 593,
+            "source_id": 59,
             "feature_display": "BARD1"
         },
         {
@@ -21103,6 +22882,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 594,
+            "feature_id": 594,
+            "source_id": 86,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21141,6 +22923,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 595,
+            "feature_id": 595,
+            "source_id": 86,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21179,6 +22964,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 596,
+            "feature_id": 596,
+            "source_id": 86,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21217,6 +23005,9 @@
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 597,
+            "feature_id": 597,
+            "source_id": 172,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21255,6 +23046,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 598,
+            "feature_id": 598,
+            "source_id": 81,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21293,6 +23087,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 599,
+            "feature_id": 599,
+            "source_id": 81,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21331,6 +23128,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 600,
+            "feature_id": 600,
+            "source_id": 81,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21369,6 +23169,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 601,
+            "feature_id": 601,
+            "source_id": 173,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21407,6 +23210,9 @@
             "publication_date": "2015-02-25",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 602,
+            "feature_id": 602,
+            "source_id": 85,
             "feature_display": "BRCA1"
         },
         {
@@ -21445,6 +23251,9 @@
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 603,
+            "feature_id": 603,
+            "source_id": 174,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21483,6 +23292,9 @@
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 604,
+            "feature_id": 604,
+            "source_id": 174,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21521,6 +23333,9 @@
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 605,
+            "feature_id": 605,
+            "source_id": 174,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21559,6 +23374,9 @@
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 606,
+            "feature_id": 606,
+            "source_id": 174,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21597,6 +23415,9 @@
             "publication_date": "2020-10-01",
             "last_updated": "2021-09-16",
             "_deprecated": false,
+            "assertion_id": 607,
+            "feature_id": 607,
+            "source_id": 175,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21635,6 +23456,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 608,
+            "feature_id": 608,
+            "source_id": 86,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21673,6 +23497,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 609,
+            "feature_id": 609,
+            "source_id": 86,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21711,6 +23538,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 610,
+            "feature_id": 610,
+            "source_id": 86,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21749,6 +23579,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 611,
+            "feature_id": 611,
+            "source_id": 58,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -21787,6 +23620,9 @@
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 612,
+            "feature_id": 612,
+            "source_id": 174,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21825,6 +23661,9 @@
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 613,
+            "feature_id": 613,
+            "source_id": 174,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21863,6 +23702,9 @@
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 614,
+            "feature_id": 614,
+            "source_id": 174,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21901,6 +23743,9 @@
             "publication_date": "2019-07-02",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 615,
+            "feature_id": 615,
+            "source_id": 174,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21939,6 +23784,9 @@
             "publication_date": "2020-10-01",
             "last_updated": "2021-09-16",
             "_deprecated": false,
+            "assertion_id": 616,
+            "feature_id": 616,
+            "source_id": 176,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -21977,6 +23825,9 @@
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 617,
+            "feature_id": 617,
+            "source_id": 172,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -22015,6 +23866,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 618,
+            "feature_id": 618,
+            "source_id": 86,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -22053,6 +23907,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 619,
+            "feature_id": 619,
+            "source_id": 86,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -22091,6 +23948,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-10-15",
             "_deprecated": false,
+            "assertion_id": 620,
+            "feature_id": 620,
+            "source_id": 86,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -22129,6 +23989,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 621,
+            "feature_id": 621,
+            "source_id": 177,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -22167,6 +24030,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 622,
+            "feature_id": 622,
+            "source_id": 177,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -22205,6 +24071,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 623,
+            "feature_id": 623,
+            "source_id": 177,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -22243,6 +24112,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 624,
+            "feature_id": 624,
+            "source_id": 173,
             "feature_display": "BRCA2"
         },
         {
@@ -22281,6 +24153,9 @@
             "publication_date": "2015-10-29",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 625,
+            "feature_id": 625,
+            "source_id": 88,
             "feature_display": "BRCA2"
         },
         {
@@ -22319,6 +24194,9 @@
             "publication_date": "2015-02-25",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 626,
+            "feature_id": 626,
+            "source_id": 85,
             "feature_display": "BRCA2"
         },
         {
@@ -22357,6 +24235,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2020-10-22",
             "_deprecated": false,
+            "assertion_id": 627,
+            "feature_id": 627,
+            "source_id": 58,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -22395,6 +24276,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 628,
+            "feature_id": 628,
+            "source_id": 59,
             "feature_display": "CHEK1"
         },
         {
@@ -22433,6 +24317,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 629,
+            "feature_id": 629,
+            "source_id": 59,
             "feature_display": "CHEK1"
         },
         {
@@ -22471,6 +24358,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 630,
+            "feature_id": 630,
+            "source_id": 59,
             "feature_display": "CHEK1"
         },
         {
@@ -22509,6 +24399,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 631,
+            "feature_id": 631,
+            "source_id": 59,
             "feature_display": "CHEK1"
         },
         {
@@ -22547,6 +24440,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 632,
+            "feature_id": 632,
+            "source_id": 59,
             "feature_display": "CHEK1"
         },
         {
@@ -22585,6 +24481,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 633,
+            "feature_id": 633,
+            "source_id": 59,
             "feature_display": "CHEK1"
         },
         {
@@ -22623,6 +24522,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 634,
+            "feature_id": 634,
+            "source_id": 59,
             "feature_display": "CHEK2"
         },
         {
@@ -22661,6 +24563,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 635,
+            "feature_id": 635,
+            "source_id": 59,
             "feature_display": "CHEK2"
         },
         {
@@ -22699,6 +24604,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 636,
+            "feature_id": 636,
+            "source_id": 59,
             "feature_display": "CHEK2"
         },
         {
@@ -22737,6 +24645,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 637,
+            "feature_id": 637,
+            "source_id": 59,
             "feature_display": "CHEK2"
         },
         {
@@ -22775,6 +24686,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 638,
+            "feature_id": 638,
+            "source_id": 59,
             "feature_display": "CHEK2"
         },
         {
@@ -22813,6 +24727,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 639,
+            "feature_id": 639,
+            "source_id": 59,
             "feature_display": "CHEK2"
         },
         {
@@ -22851,6 +24768,9 @@
             "publication_date": "2019-01-24",
             "last_updated": "2019-04-16",
             "_deprecated": false,
+            "assertion_id": 640,
+            "feature_id": 640,
+            "source_id": 178,
             "feature_display": "CHEK2 (Pathogenic)"
         },
         {
@@ -22889,6 +24809,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 641,
+            "feature_id": 641,
+            "source_id": 80,
             "feature_display": "EPCAM"
         },
         {
@@ -22927,6 +24850,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 642,
+            "feature_id": 642,
+            "source_id": 179,
             "feature_display": "IL12RB1 p.Q32* (Nonsense)"
         },
         {
@@ -22965,6 +24891,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 643,
+            "feature_id": 643,
+            "source_id": 179,
             "feature_display": "IL12RB1 p.Q542* (Nonsense)"
         },
         {
@@ -23003,6 +24932,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 644,
+            "feature_id": 644,
+            "source_id": 179,
             "feature_display": "LIMK2 p.G574Rfs*12 (Frameshift)"
         },
         {
@@ -23041,6 +24973,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 645,
+            "feature_id": 645,
+            "source_id": 179,
             "feature_display": "LIMK2 p.C582Lfs*4 (Frameshift)"
         },
         {
@@ -23079,6 +25014,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 646,
+            "feature_id": 646,
+            "source_id": 179,
             "feature_display": "LIMK2 p.G684Tfs*16 (Frameshift)"
         },
         {
@@ -23117,6 +25055,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 647,
+            "feature_id": 647,
+            "source_id": 80,
             "feature_display": "MLH1"
         },
         {
@@ -23155,6 +25096,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 648,
+            "feature_id": 648,
+            "source_id": 147,
             "feature_display": "MLH3"
         },
         {
@@ -23193,6 +25137,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 649,
+            "feature_id": 649,
+            "source_id": 179,
             "feature_display": "MRE11 p.R576* (Nonsense)"
         },
         {
@@ -23231,6 +25178,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 650,
+            "feature_id": 650,
+            "source_id": 179,
             "feature_display": "MRE11 p.H356Tfs*34 (Frameshift)"
         },
         {
@@ -23269,6 +25219,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 651,
+            "feature_id": 651,
+            "source_id": 179,
             "feature_display": "MRE11 p.L7fs*18 (Frameshift)"
         },
         {
@@ -23307,6 +25260,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 652,
+            "feature_id": 652,
+            "source_id": 80,
             "feature_display": "MSH2"
         },
         {
@@ -23345,6 +25301,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 653,
+            "feature_id": 653,
+            "source_id": 147,
             "feature_display": "MSH2"
         },
         {
@@ -23383,6 +25342,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 654,
+            "feature_id": 654,
+            "source_id": 80,
             "feature_display": "MSH6"
         },
         {
@@ -23421,6 +25383,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 655,
+            "feature_id": 655,
+            "source_id": 147,
             "feature_display": "MSH6"
         },
         {
@@ -23459,6 +25424,9 @@
             "publication_date": "2008-12-16",
             "last_updated": "2019-09-12",
             "_deprecated": false,
+            "assertion_id": 656,
+            "feature_id": 656,
+            "source_id": 180,
             "feature_display": "NF1"
         },
         {
@@ -23497,6 +25465,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 657,
+            "feature_id": 657,
+            "source_id": 59,
             "feature_display": "PALB2"
         },
         {
@@ -23535,6 +25506,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 658,
+            "feature_id": 658,
+            "source_id": 59,
             "feature_display": "PALB2"
         },
         {
@@ -23573,6 +25547,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 659,
+            "feature_id": 659,
+            "source_id": 59,
             "feature_display": "PALB2"
         },
         {
@@ -23611,6 +25588,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 660,
+            "feature_id": 660,
+            "source_id": 59,
             "feature_display": "PALB2"
         },
         {
@@ -23649,6 +25629,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 661,
+            "feature_id": 661,
+            "source_id": 59,
             "feature_display": "PALB2"
         },
         {
@@ -23687,6 +25670,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 662,
+            "feature_id": 662,
+            "source_id": 59,
             "feature_display": "PALB2"
         },
         {
@@ -23725,6 +25711,9 @@
             "publication_date": "2015-02-25",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 663,
+            "feature_id": 663,
+            "source_id": 85,
             "feature_display": "PALB2"
         },
         {
@@ -23763,6 +25752,9 @@
             "publication_date": "2018-02-22",
             "last_updated": "2019-04-16",
             "_deprecated": false,
+            "assertion_id": 664,
+            "feature_id": 664,
+            "source_id": 171,
             "feature_display": "PALB2 (Pathogenic)"
         },
         {
@@ -23801,6 +25793,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 665,
+            "feature_id": 665,
+            "source_id": 80,
             "feature_display": "PMS2"
         },
         {
@@ -23839,6 +25834,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 666,
+            "feature_id": 666,
+            "source_id": 179,
             "feature_display": "POLE2 p.L469Ffs*17 (Frameshift)"
         },
         {
@@ -23877,6 +25875,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 667,
+            "feature_id": 667,
+            "source_id": 179,
             "feature_display": "POT1 p.D617Efs*9 (Frameshift)"
         },
         {
@@ -23915,6 +25916,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 668,
+            "feature_id": 668,
+            "source_id": 179,
             "feature_display": "POT1 p.R363* (Nonsense)"
         },
         {
@@ -23953,6 +25957,9 @@
             "publication_date": "2016-06-22",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 669,
+            "feature_id": 669,
+            "source_id": 179,
             "feature_display": "POT1 p.N75Kfs*16 (Frameshift)"
         },
         {
@@ -23991,6 +25998,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 670,
+            "feature_id": 670,
+            "source_id": 59,
             "feature_display": "RAD51C"
         },
         {
@@ -24029,6 +26039,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 671,
+            "feature_id": 671,
+            "source_id": 59,
             "feature_display": "RAD51C"
         },
         {
@@ -24067,6 +26080,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 672,
+            "feature_id": 672,
+            "source_id": 59,
             "feature_display": "RAD51C"
         },
         {
@@ -24105,6 +26121,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 673,
+            "feature_id": 673,
+            "source_id": 59,
             "feature_display": "RAD51C"
         },
         {
@@ -24143,6 +26162,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 674,
+            "feature_id": 674,
+            "source_id": 59,
             "feature_display": "RAD51C"
         },
         {
@@ -24181,6 +26203,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 675,
+            "feature_id": 675,
+            "source_id": 59,
             "feature_display": "RAD51C"
         },
         {
@@ -24219,6 +26244,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 676,
+            "feature_id": 676,
+            "source_id": 59,
             "feature_display": "RAD51D"
         },
         {
@@ -24257,6 +26285,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 677,
+            "feature_id": 677,
+            "source_id": 59,
             "feature_display": "RAD51D"
         },
         {
@@ -24295,6 +26326,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 678,
+            "feature_id": 678,
+            "source_id": 59,
             "feature_display": "RAD51D"
         },
         {
@@ -24333,6 +26367,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 679,
+            "feature_id": 679,
+            "source_id": 59,
             "feature_display": "RAD51D"
         },
         {
@@ -24371,6 +26408,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 680,
+            "feature_id": 680,
+            "source_id": 59,
             "feature_display": "RAD51D"
         },
         {
@@ -24409,6 +26449,9 @@
             "publication_date": "2014-02-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 681,
+            "feature_id": 681,
+            "source_id": 59,
             "feature_display": "RAD51D"
         },
         {
@@ -24447,6 +26490,9 @@
             "publication_date": "2009-12-16",
             "last_updated": "2019-09-12",
             "_deprecated": false,
+            "assertion_id": 682,
+            "feature_id": 682,
+            "source_id": 180,
             "feature_display": "RB1"
         },
         {
@@ -24485,6 +26531,9 @@
             "publication_date": "2008-12-16",
             "last_updated": "2019-09-12",
             "_deprecated": false,
+            "assertion_id": 683,
+            "feature_id": 683,
+            "source_id": 180,
             "feature_display": "TP53"
         },
         {
@@ -24513,6 +26562,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 684,
+            "feature_id": 684,
+            "source_id": 181,
             "feature_display": "AR Amplification"
         },
         {
@@ -24541,6 +26593,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 685,
+            "feature_id": 685,
+            "source_id": 181,
             "feature_display": "AR Amplification"
         },
         {
@@ -24569,6 +26624,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 686,
+            "feature_id": 686,
+            "source_id": 181,
             "feature_display": "AR Amplification"
         },
         {
@@ -24597,6 +26655,9 @@
             "publication_date": "2017-08-18",
             "last_updated": "2019-08-09",
             "_deprecated": false,
+            "assertion_id": 687,
+            "feature_id": 687,
+            "source_id": 182,
             "feature_display": "AR Amplification"
         },
         {
@@ -24625,6 +26686,9 @@
             "publication_date": "2018-05-07",
             "last_updated": "2019-02-04",
             "_deprecated": false,
+            "assertion_id": 688,
+            "feature_id": 688,
+            "source_id": 53,
             "feature_display": "ARID1A Deletion"
         },
         {
@@ -24653,6 +26717,9 @@
             "publication_date": "2011-11-16",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 689,
+            "feature_id": 689,
+            "source_id": 183,
             "feature_display": "AURKA Amplification"
         },
         {
@@ -24681,6 +26748,9 @@
             "publication_date": "2011-12-29",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 690,
+            "feature_id": 690,
+            "source_id": 184,
             "feature_display": "AURKA Amplification"
         },
         {
@@ -24709,6 +26779,9 @@
             "publication_date": "2016-10-02",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 691,
+            "feature_id": 691,
+            "source_id": 185,
             "feature_display": "AURKB Amplification"
         },
         {
@@ -24737,6 +26810,9 @@
             "publication_date": "2010-11-23",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 692,
+            "feature_id": 692,
+            "source_id": 186,
             "feature_display": "BRAF Amplification"
         },
         {
@@ -24765,6 +26841,9 @@
             "publication_date": "2014-01-07",
             "last_updated": "2019-06-13",
             "_deprecated": false,
+            "assertion_id": 693,
+            "feature_id": 693,
+            "source_id": 78,
             "feature_display": "BRAF Amplification"
         },
         {
@@ -24793,6 +26872,9 @@
             "publication_date": "2015-10-29",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 694,
+            "feature_id": 694,
+            "source_id": 88,
             "feature_display": "BRCA2 Deletion"
         },
         {
@@ -24821,6 +26903,9 @@
             "publication_date": "2007-05-07",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 695,
+            "feature_id": 695,
+            "source_id": 187,
             "feature_display": "CCND1 Amplification"
         },
         {
@@ -24849,6 +26934,9 @@
             "publication_date": "2015-04-09",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 696,
+            "feature_id": 696,
+            "source_id": 54,
             "feature_display": "CCND1 Amplification"
         },
         {
@@ -24877,6 +26965,9 @@
             "publication_date": "2013-11-11",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 697,
+            "feature_id": 697,
+            "source_id": 188,
             "feature_display": "CCNE1 Amplification"
         },
         {
@@ -24905,6 +26996,9 @@
             "publication_date": "2015-05-21",
             "last_updated": "2019-11-04",
             "_deprecated": false,
+            "assertion_id": 698,
+            "feature_id": 698,
+            "source_id": 189,
             "feature_display": "CD274 Amplification"
         },
         {
@@ -24933,6 +27027,9 @@
             "publication_date": "2020-09-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 699,
+            "feature_id": 699,
+            "source_id": 190,
             "feature_display": "CD274 Amplification"
         },
         {
@@ -24953,14 +27050,17 @@
             "predictive_implication": "Inferential",
             "description": "The U.S. Food and Drug Administration granted accelerated approval to pembrolizumab in combination with chemotherapy for the treatment of patients with locally recurrent unresectable or metastatic triple-negative breast cancer (TNBC) whose tumors express PD-L1 (CPS>=10) as determined by an FDA approved test.",
             "source_type": "FDA",
-            "citation": "Merck Sharp & Dohme Corp. Keytruda (pembrolizumab) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125514s085lbl.pdf. Revised October 2020. Accessed November 4, 2020.",
+            "citation": "Merck Sharp & Dohme Corp. Keytruda (pembrolizumab) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125514s088lbl.pdf. Revised November 2020. Accessed November 4, 2020.",
             "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125514s088lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
             "publication_date": "2020-10-01",
-            "last_updated": "2020-11-19",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 700,
+            "feature_id": 700,
+            "source_id": 191,
             "feature_display": "CD274 Amplification"
         },
         {
@@ -24989,6 +27089,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2021-05-06",
             "_deprecated": false,
+            "assertion_id": 701,
+            "feature_id": 701,
+            "source_id": 192,
             "feature_display": "CD274 Amplification"
         },
         {
@@ -25017,6 +27120,9 @@
             "publication_date": "2020-05-01",
             "last_updated": "2021-05-06",
             "_deprecated": false,
+            "assertion_id": 702,
+            "feature_id": 702,
+            "source_id": 192,
             "feature_display": "CD274 Amplification"
         },
         {
@@ -25045,6 +27151,9 @@
             "publication_date": "2021-10-01",
             "last_updated": "2021-11-03",
             "_deprecated": false,
+            "assertion_id": 703,
+            "feature_id": 703,
+            "source_id": 193,
             "feature_display": "CD274 Amplification"
         },
         {
@@ -25073,6 +27182,9 @@
             "publication_date": "2021-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 704,
+            "feature_id": 704,
+            "source_id": 194,
             "feature_display": "CDK4 Amplification"
         },
         {
@@ -25101,6 +27213,9 @@
             "publication_date": "2021-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 705,
+            "feature_id": 705,
+            "source_id": 194,
             "feature_display": "CDK4 Amplification"
         },
         {
@@ -25129,6 +27244,9 @@
             "publication_date": "2013-04-08",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 706,
+            "feature_id": 706,
+            "source_id": 195,
             "feature_display": "CDK4 Amplification"
         },
         {
@@ -25157,6 +27275,9 @@
             "publication_date": "2015-04-09",
             "last_updated": "2018-09-14",
             "_deprecated": false,
+            "assertion_id": 707,
+            "feature_id": 707,
+            "source_id": 54,
             "feature_display": "CDK4 Amplification"
         },
         {
@@ -25185,6 +27306,9 @@
             "publication_date": "2016-02-11",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 708,
+            "feature_id": 708,
+            "source_id": 196,
             "feature_display": "CDKN2A Deletion"
         },
         {
@@ -25213,6 +27337,9 @@
             "publication_date": "2015-04-09",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 709,
+            "feature_id": 709,
+            "source_id": 54,
             "feature_display": "CDKN2A Deletion"
         },
         {
@@ -25241,6 +27368,9 @@
             "publication_date": "2008-09-30",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 710,
+            "feature_id": 710,
+            "source_id": 197,
             "feature_display": "CDKN2C Deletion"
         },
         {
@@ -25269,6 +27399,9 @@
             "publication_date": "2016-08-17",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 711,
+            "feature_id": 711,
+            "source_id": 16,
             "feature_display": "CDKN2C Deletion"
         },
         {
@@ -25297,6 +27430,9 @@
             "publication_date": "2011-12-13",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 712,
+            "feature_id": 712,
+            "source_id": 198,
             "feature_display": "CRKL Amplification"
         },
         {
@@ -25325,6 +27461,9 @@
             "publication_date": "2005-10-01",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 713,
+            "feature_id": 713,
+            "source_id": 96,
             "feature_display": "EGFR Amplification"
         },
         {
@@ -25353,6 +27492,9 @@
             "publication_date": "2010-02-01",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 714,
+            "feature_id": 714,
+            "source_id": 199,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25381,6 +27523,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 715,
+            "feature_id": 715,
+            "source_id": 200,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25409,6 +27554,9 @@
             "publication_date": "2018-12-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 716,
+            "feature_id": 716,
+            "source_id": 201,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25437,6 +27585,9 @@
             "publication_date": "2018-12-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 717,
+            "feature_id": 717,
+            "source_id": 201,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25465,6 +27616,9 @@
             "publication_date": "2017-07-17",
             "last_updated": "2024-01-11",
             "_deprecated": false,
+            "assertion_id": 718,
+            "feature_id": 718,
+            "source_id": 202,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25493,6 +27647,9 @@
             "publication_date": "2020-01-01",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 719,
+            "feature_id": 719,
+            "source_id": 203,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25521,6 +27678,9 @@
             "publication_date": "2018-11-01",
             "last_updated": "2021-05-06",
             "_deprecated": false,
+            "assertion_id": 720,
+            "feature_id": 720,
+            "source_id": 204,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25549,6 +27709,9 @@
             "publication_date": "2018-11-01",
             "last_updated": "2021-05-06",
             "_deprecated": false,
+            "assertion_id": 721,
+            "feature_id": 721,
+            "source_id": 204,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25577,6 +27740,9 @@
             "publication_date": "2018-11-01",
             "last_updated": "2021-05-06",
             "_deprecated": false,
+            "assertion_id": 722,
+            "feature_id": 722,
+            "source_id": 204,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25605,6 +27771,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 723,
+            "feature_id": 723,
+            "source_id": 205,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25633,6 +27802,9 @@
             "publication_date": "2020-04-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 724,
+            "feature_id": 724,
+            "source_id": 206,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25661,6 +27833,9 @@
             "publication_date": "1999-01-06",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 725,
+            "feature_id": 725,
+            "source_id": 207,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25689,6 +27864,9 @@
             "publication_date": "2003-11-14",
             "last_updated": "2019-08-09",
             "_deprecated": false,
+            "assertion_id": 726,
+            "feature_id": 726,
+            "source_id": 208,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25717,6 +27895,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 727,
+            "feature_id": 727,
+            "source_id": 209,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25745,6 +27926,9 @@
             "publication_date": "2020-06-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 728,
+            "feature_id": 728,
+            "source_id": 209,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25773,6 +27957,9 @@
             "publication_date": "2020-12-01",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 729,
+            "feature_id": 729,
+            "source_id": 210,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25801,6 +27988,9 @@
             "publication_date": "2023-11-08",
             "last_updated": "2023-12-05",
             "_deprecated": false,
+            "assertion_id": 730,
+            "feature_id": 730,
+            "source_id": 211,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25829,6 +28019,9 @@
             "publication_date": "2023-11-08",
             "last_updated": "2023-12-05",
             "_deprecated": false,
+            "assertion_id": 731,
+            "feature_id": 731,
+            "source_id": 211,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -25857,6 +28050,9 @@
             "publication_date": "2010-06-17",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 732,
+            "feature_id": 732,
+            "source_id": 212,
             "feature_display": "ESR1 Amplification"
         },
         {
@@ -25885,6 +28081,9 @@
             "publication_date": "2008-09-12",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 733,
+            "feature_id": 733,
+            "source_id": 109,
             "feature_display": "FBXW7 Deletion"
         },
         {
@@ -25913,6 +28112,9 @@
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 734,
+            "feature_id": 734,
+            "source_id": 213,
             "feature_display": "FGFR1 Amplification"
         },
         {
@@ -25941,6 +28143,9 @@
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 735,
+            "feature_id": 735,
+            "source_id": 213,
             "feature_display": "FGFR1 Amplification"
         },
         {
@@ -25969,6 +28174,9 @@
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 736,
+            "feature_id": 736,
+            "source_id": 213,
             "feature_display": "FGFR1 Amplification"
         },
         {
@@ -25997,6 +28205,9 @@
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 737,
+            "feature_id": 737,
+            "source_id": 213,
             "feature_display": "FGFR1 Amplification"
         },
         {
@@ -26025,6 +28236,9 @@
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 738,
+            "feature_id": 738,
+            "source_id": 213,
             "feature_display": "FGFR2 Amplification"
         },
         {
@@ -26053,6 +28267,9 @@
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 739,
+            "feature_id": 739,
+            "source_id": 213,
             "feature_display": "FGFR2 Amplification"
         },
         {
@@ -26081,6 +28298,9 @@
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 740,
+            "feature_id": 740,
+            "source_id": 213,
             "feature_display": "FGFR2 Amplification"
         },
         {
@@ -26109,6 +28329,9 @@
             "publication_date": "2012-12-09",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 741,
+            "feature_id": 741,
+            "source_id": 213,
             "feature_display": "FGFR2 Amplification"
         },
         {
@@ -26137,6 +28360,9 @@
             "publication_date": "2014-06-17",
             "last_updated": "2019-08-09",
             "_deprecated": false,
+            "assertion_id": 742,
+            "feature_id": 742,
+            "source_id": 214,
             "feature_display": "HIF1a Amplification"
         },
         {
@@ -26165,6 +28391,9 @@
             "publication_date": "2017-01-05",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 743,
+            "feature_id": 743,
+            "source_id": 215,
             "feature_display": "KEAP1 Deletion"
         },
         {
@@ -26193,6 +28422,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 744,
+            "feature_id": 744,
+            "source_id": 126,
             "feature_display": "KIT Amplification"
         },
         {
@@ -26221,6 +28453,9 @@
             "publication_date": "2010-12-07",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 745,
+            "feature_id": 745,
+            "source_id": 168,
             "feature_display": "MDM2 Amplification"
         },
         {
@@ -26249,6 +28484,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 746,
+            "feature_id": 746,
+            "source_id": 11,
             "feature_display": "MET Amplification"
         },
         {
@@ -26277,6 +28515,9 @@
             "publication_date": "2017-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 747,
+            "feature_id": 747,
+            "source_id": 20,
             "feature_display": "MET Amplification"
         },
         {
@@ -26305,6 +28546,9 @@
             "publication_date": "2015-11-05",
             "last_updated": "2019-08-12",
             "_deprecated": false,
+            "assertion_id": 748,
+            "feature_id": 748,
+            "source_id": 216,
             "feature_display": "MET Amplification"
         },
         {
@@ -26328,11 +28572,14 @@
             "citation": "A phase 1 trial of crizotinib (NCT00585195) in patients with MET amplified non-small cell lung cancer observed an objective response rate of 6 out of 15 patients with MET amplified gene copy number greater than or equal to 6. The study enrolled 38 patients with MET-to-CEP7 ratios greater than equal to 1.8 by local FISH testing.",
             "url": "https://doi.org/10.1016/j.jtho.2021.02.010",
             "doi": "10.1016/j.jtho.2021.02.010",
-            "pmid": "33676017",
+            "pmid": 33676017,
             "nct": "",
             "publication_date": "2021-03-04",
-            "last_updated": "2024-03-05",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 749,
+            "feature_id": 749,
+            "source_id": 217,
             "feature_display": "MET Amplification"
         },
         {
@@ -26361,6 +28608,9 @@
             "publication_date": "2016-05-06",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 750,
+            "feature_id": 750,
+            "source_id": 218,
             "feature_display": "MIR17HG Amplification"
         },
         {
@@ -26389,6 +28639,9 @@
             "publication_date": "2016-05-06",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 751,
+            "feature_id": 751,
+            "source_id": 218,
             "feature_display": "MIR17HG Deletion"
         },
         {
@@ -26417,6 +28670,9 @@
             "publication_date": "2010-09-14",
             "last_updated": "2019-08-08",
             "_deprecated": false,
+            "assertion_id": 752,
+            "feature_id": 752,
+            "source_id": 219,
             "feature_display": "MRE11 Amplification"
         },
         {
@@ -26445,6 +28701,9 @@
             "publication_date": "2011-12-03",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 753,
+            "feature_id": 753,
+            "source_id": 220,
             "feature_display": "MYC Amplification"
         },
         {
@@ -26473,6 +28732,9 @@
             "publication_date": "2015-04-09",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 754,
+            "feature_id": 754,
+            "source_id": 54,
             "feature_display": "MYC Amplification"
         },
         {
@@ -26501,6 +28763,9 @@
             "publication_date": "2007-05-07",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 755,
+            "feature_id": 755,
+            "source_id": 187,
             "feature_display": "PAK1 Amplification"
         },
         {
@@ -26529,6 +28794,9 @@
             "publication_date": "2007-05-07",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 756,
+            "feature_id": 756,
+            "source_id": 187,
             "feature_display": "PAK1 Amplification"
         },
         {
@@ -26557,6 +28825,9 @@
             "publication_date": "2018-01-04",
             "last_updated": "2018-11-29",
             "_deprecated": false,
+            "assertion_id": 757,
+            "feature_id": 757,
+            "source_id": 153,
             "feature_display": "PBRM1 Deletion"
         },
         {
@@ -26585,6 +28856,9 @@
             "publication_date": "2015-01-05",
             "last_updated": "2019-01-29",
             "_deprecated": false,
+            "assertion_id": 758,
+            "feature_id": 758,
+            "source_id": 221,
             "feature_display": "PIK3CA Amplification"
         },
         {
@@ -26613,6 +28887,9 @@
             "publication_date": "2014-12-16",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 759,
+            "feature_id": 759,
+            "source_id": 158,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -26641,6 +28918,9 @@
             "publication_date": "2017-02-21",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 760,
+            "feature_id": 760,
+            "source_id": 159,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -26669,6 +28949,9 @@
             "publication_date": "2014-04-09",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 761,
+            "feature_id": 761,
+            "source_id": 222,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -26697,6 +28980,9 @@
             "publication_date": "2016-02-04",
             "last_updated": "2019-03-07",
             "_deprecated": false,
+            "assertion_id": 762,
+            "feature_id": 762,
+            "source_id": 160,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -26725,6 +29011,9 @@
             "publication_date": "2019-01-15",
             "last_updated": "2019-08-12",
             "_deprecated": false,
+            "assertion_id": 763,
+            "feature_id": 763,
+            "source_id": 149,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -26753,6 +29042,9 @@
             "publication_date": "2019-01-15",
             "last_updated": "2019-08-12",
             "_deprecated": false,
+            "assertion_id": 764,
+            "feature_id": 764,
+            "source_id": 149,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -26781,6 +29073,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 765,
+            "feature_id": 765,
+            "source_id": 28,
             "feature_display": "RB1 Deletion"
         },
         {
@@ -26809,6 +29104,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 766,
+            "feature_id": 766,
+            "source_id": 28,
             "feature_display": "TP53 Deletion"
         },
         {
@@ -26837,6 +29135,9 @@
             "publication_date": "2011-12-29",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 767,
+            "feature_id": 767,
+            "source_id": 184,
             "feature_display": "TPX2 Amplification"
         },
         {
@@ -26863,6 +29164,9 @@
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 768,
+            "feature_id": 768,
+            "source_id": 223,
             "feature_display": "MSI-High"
         },
         {
@@ -26889,6 +29193,9 @@
             "publication_date": "2020-10-01",
             "last_updated": "2020-11-12",
             "_deprecated": false,
+            "assertion_id": 769,
+            "feature_id": 769,
+            "source_id": 223,
             "feature_display": "MSI-High"
         },
         {
@@ -26915,6 +29222,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 770,
+            "feature_id": 770,
+            "source_id": 80,
             "feature_display": "MSI-High"
         },
         {
@@ -26941,6 +29251,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 771,
+            "feature_id": 771,
+            "source_id": 80,
             "feature_display": "MSI-High"
         },
         {
@@ -26967,6 +29280,9 @@
             "publication_date": "2016-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 772,
+            "feature_id": 772,
+            "source_id": 80,
             "feature_display": "MSI-High"
         },
         {
@@ -26993,6 +29309,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 773,
+            "feature_id": 773,
+            "source_id": 147,
             "feature_display": "MSI-High"
         },
         {
@@ -27019,6 +29338,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 774,
+            "feature_id": 774,
+            "source_id": 147,
             "feature_display": "Cosmic signature SBS10a (version 3.4)"
         },
         {
@@ -27045,6 +29367,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 775,
+            "feature_id": 775,
+            "source_id": 147,
             "feature_display": "Cosmic signature SBS10b (version 3.4)"
         },
         {
@@ -27071,6 +29396,9 @@
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 776,
+            "feature_id": 776,
+            "source_id": 157,
             "feature_display": "Cosmic signature SBS10a (version 3.4)"
         },
         {
@@ -27097,6 +29425,9 @@
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 777,
+            "feature_id": 777,
+            "source_id": 157,
             "feature_display": "Cosmic signature SBS10b (version 3.4)"
         },
         {
@@ -27123,6 +29454,9 @@
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 778,
+            "feature_id": 778,
+            "source_id": 157,
             "feature_display": "Cosmic signature SBS10a (version 3.4)"
         },
         {
@@ -27149,6 +29483,9 @@
             "publication_date": "2017-07-05",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 779,
+            "feature_id": 779,
+            "source_id": 157,
             "feature_display": "Cosmic signature SBS10b (version 3.4)"
         },
         {
@@ -27175,6 +29512,9 @@
             "publication_date": "2016-06-10",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 780,
+            "feature_id": 780,
+            "source_id": 224,
             "feature_display": "Cosmic signature SBS2 (version 3.4)"
         },
         {
@@ -27201,6 +29541,9 @@
             "publication_date": "2016-06-10",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 781,
+            "feature_id": 781,
+            "source_id": 224,
             "feature_display": "Cosmic signature SBS2 (version 3.4)"
         },
         {
@@ -27227,6 +29570,9 @@
             "publication_date": "2015-10-29",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 782,
+            "feature_id": 782,
+            "source_id": 225,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -27253,6 +29599,9 @@
             "publication_date": "2015-10-29",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 783,
+            "feature_id": 783,
+            "source_id": 225,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -27279,6 +29628,9 @@
             "publication_date": "2015-10-29",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 784,
+            "feature_id": 784,
+            "source_id": 225,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -27305,6 +29657,9 @@
             "publication_date": "2015-10-29",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 785,
+            "feature_id": 785,
+            "source_id": 225,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -27331,6 +29686,9 @@
             "publication_date": "2015-10-29",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 786,
+            "feature_id": 786,
+            "source_id": 225,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -27357,6 +29715,9 @@
             "publication_date": "2015-02-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 787,
+            "feature_id": 787,
+            "source_id": 85,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -27383,6 +29744,9 @@
             "publication_date": "2015-03-12",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 788,
+            "feature_id": 788,
+            "source_id": 136,
             "feature_display": "Cosmic signature SBS4 (version 3.4)"
         },
         {
@@ -27409,6 +29773,9 @@
             "publication_date": "2015-03-12",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 789,
+            "feature_id": 789,
+            "source_id": 136,
             "feature_display": "Cosmic signature SBS4 (version 3.4)"
         },
         {
@@ -27435,6 +29802,9 @@
             "publication_date": "2016-04-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 790,
+            "feature_id": 790,
+            "source_id": 226,
             "feature_display": "Cosmic signature SBS5 (version 3.4)"
         },
         {
@@ -27461,6 +29831,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 791,
+            "feature_id": 791,
+            "source_id": 87,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -27487,6 +29860,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 792,
+            "feature_id": 792,
+            "source_id": 87,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -27513,6 +29889,9 @@
             "publication_date": "2020-11-01",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 793,
+            "feature_id": 793,
+            "source_id": 87,
             "feature_display": "Cosmic signature SBS3 (version 3.4)"
         },
         {
@@ -27541,6 +29920,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 794,
+            "feature_id": 794,
+            "source_id": 11,
             "feature_display": "High mutational burden"
         },
         {
@@ -27569,6 +29951,9 @@
             "publication_date": "2019-01-01",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 795,
+            "feature_id": 795,
+            "source_id": 11,
             "feature_display": "High mutational burden"
         },
         {
@@ -27597,6 +29982,9 @@
             "publication_date": "2015-03-12",
             "last_updated": "2017-03-12",
             "_deprecated": false,
+            "assertion_id": 796,
+            "feature_id": 796,
+            "source_id": 136,
             "feature_display": "High mutational burden"
         },
         {
@@ -27625,6 +30013,9 @@
             "publication_date": "2014-12-04",
             "last_updated": "2017-03-12",
             "_deprecated": false,
+            "assertion_id": 797,
+            "feature_id": 797,
+            "source_id": 227,
             "feature_display": "High mutational burden"
         },
         {
@@ -27653,6 +30044,9 @@
             "publication_date": "2015-09-10",
             "last_updated": "2017-03-12",
             "_deprecated": false,
+            "assertion_id": 798,
+            "feature_id": 798,
+            "source_id": 228,
             "feature_display": "High mutational burden"
         },
         {
@@ -27681,6 +30075,9 @@
             "publication_date": "2020-10-01",
             "last_updated": "2021-09-16",
             "_deprecated": false,
+            "assertion_id": 799,
+            "feature_id": 799,
+            "source_id": 223,
             "feature_display": "High mutational burden"
         },
         {
@@ -27708,6 +30105,9 @@
             "publication_date": "2017-04-01",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 800,
+            "feature_id": 800,
+            "source_id": 57,
             "feature_display": "ATM knockdown (shRNA)"
         },
         {
@@ -27735,6 +30135,9 @@
             "publication_date": "2017-08-07",
             "last_updated": "2019-04-16",
             "_deprecated": false,
+            "assertion_id": 801,
+            "feature_id": 801,
+            "source_id": 229,
             "feature_display": "B2M knockdown (CRISPR-Cas9)"
         },
         {
@@ -27762,6 +30165,9 @@
             "publication_date": "2014-01-05",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 802,
+            "feature_id": 802,
+            "source_id": 230,
             "feature_display": "CDK12 knockdown (shRNA)"
         },
         {
@@ -27789,6 +30195,9 @@
             "publication_date": "2014-03-08",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 803,
+            "feature_id": 803,
+            "source_id": 231,
             "feature_display": "CDK12 knockdown (siRNA)"
         },
         {
@@ -27816,6 +30225,9 @@
             "publication_date": "2016-10-25",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 804,
+            "feature_id": 804,
+            "source_id": 232,
             "feature_display": "CPT1A knockdown (shRNA)"
         },
         {
@@ -27843,6 +30255,9 @@
             "publication_date": "2011-11-03",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 805,
+            "feature_id": 805,
+            "source_id": 233,
             "feature_display": "RAD17 knockdown (shRNA)"
         },
         {
@@ -27870,6 +30285,9 @@
             "publication_date": "2011-11-03",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 806,
+            "feature_id": 806,
+            "source_id": 233,
             "feature_display": "RAD17 knockdown (shRNA)"
         },
         {
@@ -27897,6 +30315,9 @@
             "publication_date": "2011-11-03",
             "last_updated": "2017-11-03",
             "_deprecated": false,
+            "assertion_id": 807,
+            "feature_id": 807,
+            "source_id": 233,
             "feature_display": "RAD50 knockdown (shRNA)"
         },
         {
@@ -27924,6 +30345,9 @@
             "publication_date": "2017-08-07",
             "last_updated": "2019-04-16",
             "_deprecated": false,
+            "assertion_id": 808,
+            "feature_id": 808,
+            "source_id": 229,
             "feature_display": "TAP2 knockdown (CRISPR-Cas9)"
         },
         {
@@ -27951,6 +30375,9 @@
             "publication_date": "2016-08-31",
             "last_updated": "2019-04-30",
             "_deprecated": false,
+            "assertion_id": 809,
+            "feature_id": 809,
+            "source_id": 234,
             "feature_display": "PPARGC1A knockdown (CRSPR-Cas9)"
         },
         {
@@ -27977,6 +30404,9 @@
             "publication_date": "2018-07-16",
             "last_updated": "2018-09-01",
             "_deprecated": false,
+            "assertion_id": 810,
+            "feature_id": 810,
+            "source_id": 235,
             "feature_display": "Whole genome doubling"
         },
         {
@@ -28013,6 +30443,9 @@
             "publication_date": "2022-03-01",
             "last_updated": "2022-07-07",
             "_deprecated": false,
+            "assertion_id": 811,
+            "feature_id": 811,
+            "source_id": 236,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -28049,6 +30482,9 @@
             "publication_date": "2022-05-01",
             "last_updated": "2022-07-07",
             "_deprecated": false,
+            "assertion_id": 812,
+            "feature_id": 812,
+            "source_id": 237,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -28085,6 +30521,9 @@
             "publication_date": "2022-05-01",
             "last_updated": "2022-07-07",
             "_deprecated": false,
+            "assertion_id": 813,
+            "feature_id": 813,
+            "source_id": 237,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -28121,6 +30560,9 @@
             "publication_date": "2022-05-01",
             "last_updated": "2022-07-07",
             "_deprecated": false,
+            "assertion_id": 814,
+            "feature_id": 814,
+            "source_id": 237,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -28157,6 +30599,9 @@
             "publication_date": "2022-05-01",
             "last_updated": "2022-07-07",
             "_deprecated": false,
+            "assertion_id": 815,
+            "feature_id": 815,
+            "source_id": 237,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -28183,6 +30628,9 @@
             "publication_date": "2015-06-25",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 816,
+            "feature_id": 816,
+            "source_id": 147,
             "feature_display": "MSI-High"
         },
         {
@@ -28209,6 +30657,9 @@
             "publication_date": "2021-03-01",
             "last_updated": "2022-07-07",
             "_deprecated": false,
+            "assertion_id": 817,
+            "feature_id": 817,
+            "source_id": 238,
             "feature_display": "MSI-High"
         },
         {
@@ -28247,6 +30698,9 @@
             "publication_date": "2009-07-09",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 818,
+            "feature_id": 818,
+            "source_id": 239,
             "feature_display": "BRCA1"
         },
         {
@@ -28285,6 +30739,9 @@
             "publication_date": "2009-07-09",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 819,
+            "feature_id": 819,
+            "source_id": 239,
             "feature_display": "BRCA1"
         },
         {
@@ -28323,6 +30780,9 @@
             "publication_date": "2009-07-09",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 820,
+            "feature_id": 820,
+            "source_id": 239,
             "feature_display": "BRCA1"
         },
         {
@@ -28361,6 +30821,9 @@
             "publication_date": "2009-07-09",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 821,
+            "feature_id": 821,
+            "source_id": 239,
             "feature_display": "BRCA2"
         },
         {
@@ -28399,6 +30862,9 @@
             "publication_date": "2009-07-09",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 822,
+            "feature_id": 822,
+            "source_id": 239,
             "feature_display": "BRCA2"
         },
         {
@@ -28437,6 +30903,9 @@
             "publication_date": "2009-07-09",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 823,
+            "feature_id": 823,
+            "source_id": 239,
             "feature_display": "BRCA2"
         },
         {
@@ -28464,6 +30933,9 @@
             "publication_date": "2020-04-15",
             "last_updated": "2023-10-05",
             "_deprecated": false,
+            "assertion_id": 824,
+            "feature_id": 824,
+            "source_id": 240,
             "feature_display": "RB1 knockdown (shRNA)"
         },
         {
@@ -28491,6 +30963,9 @@
             "publication_date": "2010-05-07",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 825,
+            "feature_id": 825,
+            "source_id": 241,
             "feature_display": "USP11 knockdown (siRNA)"
         },
         {
@@ -28520,6 +30995,9 @@
             "publication_date": "2022-07-14",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 826,
+            "feature_id": 826,
+            "source_id": 242,
             "feature_display": "ALK Fusion"
         },
         {
@@ -28556,6 +31034,9 @@
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 827,
+            "feature_id": 827,
+            "source_id": 243,
             "feature_display": "BRCA1 (Nonsense)"
         },
         {
@@ -28592,6 +31073,9 @@
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 828,
+            "feature_id": 828,
+            "source_id": 243,
             "feature_display": "BRCA1 (Frameshift)"
         },
         {
@@ -28628,6 +31112,9 @@
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 829,
+            "feature_id": 829,
+            "source_id": 243,
             "feature_display": "BRCA1 (Nonsense)"
         },
         {
@@ -28664,6 +31151,9 @@
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 830,
+            "feature_id": 830,
+            "source_id": 243,
             "feature_display": "BRCA1 (Frameshift)"
         },
         {
@@ -28700,6 +31190,9 @@
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 831,
+            "feature_id": 831,
+            "source_id": 243,
             "feature_display": "BRCA2 (Nonsense)"
         },
         {
@@ -28736,6 +31229,9 @@
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 832,
+            "feature_id": 832,
+            "source_id": 243,
             "feature_display": "BRCA2 (Frameshift)"
         },
         {
@@ -28772,6 +31268,9 @@
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 833,
+            "feature_id": 833,
+            "source_id": 243,
             "feature_display": "BRCA2 (Nonsense)"
         },
         {
@@ -28808,6 +31307,9 @@
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 834,
+            "feature_id": 834,
+            "source_id": 243,
             "feature_display": "BRCA2 (Frameshift)"
         },
         {
@@ -28844,6 +31346,9 @@
             "publication_date": "2018-12-12",
             "last_updated": "2023-10-31",
             "_deprecated": false,
+            "assertion_id": 835,
+            "feature_id": 835,
+            "source_id": 244,
             "feature_display": "BRCA2 (Nonsense)"
         },
         {
@@ -28880,6 +31385,9 @@
             "publication_date": "2018-12-12",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 836,
+            "feature_id": 836,
+            "source_id": 244,
             "feature_display": "BRCA2 (Frameshift)"
         },
         {
@@ -28916,6 +31424,9 @@
             "publication_date": "2020-04-15",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 837,
+            "feature_id": 837,
+            "source_id": 240,
             "feature_display": "RB1 (Nonsense)"
         },
         {
@@ -28952,6 +31463,9 @@
             "publication_date": "2020-04-15",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 838,
+            "feature_id": 838,
+            "source_id": 240,
             "feature_display": "RB1 (Frameshift)"
         },
         {
@@ -28981,6 +31495,9 @@
             "publication_date": "2015-02-01",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 839,
+            "feature_id": 839,
+            "source_id": 245,
             "feature_display": "ATRX Deletion"
         },
         {
@@ -29010,6 +31527,9 @@
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 840,
+            "feature_id": 840,
+            "source_id": 243,
             "feature_display": "BRCA1 Deletion"
         },
         {
@@ -29039,6 +31559,9 @@
             "publication_date": "2005-04-14",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 841,
+            "feature_id": 841,
+            "source_id": 243,
             "feature_display": "BRCA2 Deletion"
         },
         {
@@ -29068,6 +31591,9 @@
             "publication_date": "2018-12-12",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 842,
+            "feature_id": 842,
+            "source_id": 244,
             "feature_display": "BRCA2 Deletion"
         },
         {
@@ -29097,6 +31623,9 @@
             "publication_date": "2017-03-10",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 843,
+            "feature_id": 843,
+            "source_id": 246,
             "feature_display": "CDKN2A Deletion"
         },
         {
@@ -29126,6 +31655,9 @@
             "publication_date": "2020-09-01",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 844,
+            "feature_id": 844,
+            "source_id": 247,
             "feature_display": "CDKN2C Deletion"
         },
         {
@@ -29155,6 +31687,9 @@
             "publication_date": "2012-07-01",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 845,
+            "feature_id": 845,
+            "source_id": 248,
             "feature_display": "MAP2K4 Amplification"
         },
         {
@@ -29177,13 +31712,16 @@
             "description": "Overexpression of MAPK7 and MAP2K4 were significantly associated with poor response to chemotherapy, tumor progression, and worse survival in a study of 30 patients.",
             "source_type": "Journal",
             "citation": "Tesser-Gamba, F. et al. MAPK7 and MAP2K4 as prognostic markers in osteosarcoma. Hum. Pathol. 43, 994-1002 (2012).",
-            "url": "https://doi.org/10.1016/j.humpath.2011803",
-            "doi": "10.1016/j.humpath.2011803",
+            "url": "https://doi.org/10.1016/j.humpath.2011.08.003",
+            "doi": "10.1016/j.humpath.2011.08.003",
             "pmid": 22154052,
             "nct": "",
             "publication_date": "2012-07-01",
-            "last_updated": "2022-08-04",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 846,
+            "feature_id": 846,
+            "source_id": 248,
             "feature_display": "MAP2K4 Amplification"
         },
         {
@@ -29206,13 +31744,16 @@
             "description": "Overexpression of MAPK7 and MAP2K4 were significantly associated with poor response to chemotherapy, tumor progression, and worse survival in a study of 30 patients.",
             "source_type": "Journal",
             "citation": "Tesser-Gamba, F. et al. MAPK7 and MAP2K4 as prognostic markers in osteosarcoma. Hum. Pathol. 43, 994-1002 (2012).",
-            "url": "https://doi.org/10.1016/j.humpath.2011803",
-            "doi": "10.1016/j.humpath.2011803",
+            "url": "https://doi.org/10.1016/j.humpath.2011.08.003",
+            "doi": "10.1016/j.humpath.2011.08.003",
             "pmid": 22154052,
             "nct": "",
             "publication_date": "2012-07-01",
-            "last_updated": "2022-08-04",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 847,
+            "feature_id": 847,
+            "source_id": 248,
             "feature_display": "MAP2K4 Amplification"
         },
         {
@@ -29235,13 +31776,16 @@
             "description": "Overexpression of MAPK7 and MAP2K4 were significantly associated with poor response to chemotherapy, tumor progression, and worse survival in a study of 30 patients.",
             "source_type": "Journal",
             "citation": "Tesser-Gamba, F. et al. MAPK7 and MAP2K4 as prognostic markers in osteosarcoma. Hum. Pathol. 43, 994-1002 (2012).",
-            "url": "https://doi.org/10.1016/j.humpath.2011803",
-            "doi": "10.1016/j.humpath.2011803",
+            "url": "https://doi.org/10.1016/j.humpath.2011.08.003",
+            "doi": "10.1016/j.humpath.2011.08.003",
             "pmid": 22154052,
             "nct": "",
             "publication_date": "2012-07-01",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 848,
+            "feature_id": 848,
+            "source_id": 248,
             "feature_display": "MAPK7 Amplification"
         },
         {
@@ -29271,6 +31815,9 @@
             "publication_date": "2009-03-17",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 849,
+            "feature_id": 849,
+            "source_id": 249,
             "feature_display": "MYOCD Amplification"
         },
         {
@@ -29300,6 +31847,9 @@
             "publication_date": "2005-08-01",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 850,
+            "feature_id": 850,
+            "source_id": 250,
             "feature_display": "PDGFRA Amplification"
         },
         {
@@ -29329,6 +31879,9 @@
             "publication_date": "2017-02-28",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 851,
+            "feature_id": 851,
+            "source_id": 251,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -29358,6 +31911,9 @@
             "publication_date": "2017-02-28",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 852,
+            "feature_id": 852,
+            "source_id": 251,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -29387,6 +31943,9 @@
             "publication_date": "2020-04-15",
             "last_updated": "2022-08-04",
             "_deprecated": false,
+            "assertion_id": 853,
+            "feature_id": 853,
+            "source_id": 240,
             "feature_display": "RB1 Deletion"
         },
         {
@@ -29416,6 +31975,9 @@
             "publication_date": "2022-08-01",
             "last_updated": "2022-09-08",
             "_deprecated": false,
+            "assertion_id": 854,
+            "feature_id": 854,
+            "source_id": 252,
             "feature_display": "FGFR1"
         },
         {
@@ -29445,6 +32007,9 @@
             "publication_date": "2022-09-01",
             "last_updated": "2022-10-06",
             "_deprecated": false,
+            "assertion_id": 855,
+            "feature_id": 855,
+            "source_id": 253,
             "feature_display": "FGFR2"
         },
         {
@@ -29474,6 +32039,9 @@
             "publication_date": "2024-05-29",
             "last_updated": "2024-06-03",
             "_deprecated": false,
+            "assertion_id": 856,
+            "feature_id": 856,
+            "source_id": 254,
             "feature_display": "RET Fusion"
         },
         {
@@ -29510,6 +32078,9 @@
             "publication_date": "2022-12-01",
             "last_updated": "2023-01-05",
             "_deprecated": false,
+            "assertion_id": 857,
+            "feature_id": 857,
+            "source_id": 255,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -29546,6 +32117,9 @@
             "publication_date": "2022-12-01",
             "last_updated": "2023-01-05",
             "_deprecated": false,
+            "assertion_id": 858,
+            "feature_id": 858,
+            "source_id": 255,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -29582,6 +32156,9 @@
             "publication_date": "2022-12-01",
             "last_updated": "2023-01-05",
             "_deprecated": false,
+            "assertion_id": 859,
+            "feature_id": 859,
+            "source_id": 255,
             "feature_display": "IDH1 p.R132G (Missense)"
         },
         {
@@ -29618,6 +32195,9 @@
             "publication_date": "2022-12-01",
             "last_updated": "2023-01-05",
             "_deprecated": false,
+            "assertion_id": 860,
+            "feature_id": 860,
+            "source_id": 255,
             "feature_display": "IDH1 p.R132S (Missense)"
         },
         {
@@ -29654,6 +32234,9 @@
             "publication_date": "2022-12-01",
             "last_updated": "2023-01-05",
             "_deprecated": false,
+            "assertion_id": 861,
+            "feature_id": 861,
+            "source_id": 255,
             "feature_display": "IDH1 p.R132L (Missense)"
         },
         {
@@ -29690,6 +32273,9 @@
             "publication_date": "2022-12-01",
             "last_updated": "2023-11-30",
             "_deprecated": false,
+            "assertion_id": 862,
+            "feature_id": 862,
+            "source_id": 256,
             "feature_display": "KRAS p.G12C (Missense)"
         },
         {
@@ -29718,6 +32304,9 @@
             "publication_date": "2023-01-19",
             "last_updated": "2023-02-02",
             "_deprecated": false,
+            "assertion_id": 863,
+            "feature_id": 863,
+            "source_id": 257,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -29754,6 +32343,9 @@
             "publication_date": "2023-01-27",
             "last_updated": "2023-02-02",
             "_deprecated": false,
+            "assertion_id": 864,
+            "feature_id": 864,
+            "source_id": 258,
             "feature_display": "ESR1"
         },
         {
@@ -29790,6 +32382,9 @@
             "publication_date": "2023-03-16",
             "last_updated": "2023-04-06",
             "_deprecated": false,
+            "assertion_id": 865,
+            "feature_id": 865,
+            "source_id": 259,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -29826,6 +32421,9 @@
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-05",
             "_deprecated": false,
+            "assertion_id": 866,
+            "feature_id": 866,
+            "source_id": 172,
             "feature_display": "BRCA1"
         },
         {
@@ -29860,8 +32458,11 @@
             "pmid": "",
             "nct": "",
             "publication_date": "2023-03-11",
-            "last_updated": "2023-07-05",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 867,
+            "feature_id": 867,
+            "source_id": 172,
             "feature_display": "BRCA2"
         },
         {
@@ -29899,6 +32500,9 @@
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-05",
             "_deprecated": false,
+            "assertion_id": 868,
+            "feature_id": 868,
+            "source_id": 172,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -29936,6 +32540,9 @@
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-05",
             "_deprecated": false,
+            "assertion_id": 869,
+            "feature_id": 869,
+            "source_id": 172,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -29973,6 +32580,9 @@
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-05",
             "_deprecated": false,
+            "assertion_id": 870,
+            "feature_id": 870,
+            "source_id": 172,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -30010,6 +32620,9 @@
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-05",
             "_deprecated": false,
+            "assertion_id": 871,
+            "feature_id": 871,
+            "source_id": 172,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -30048,6 +32661,9 @@
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 872,
+            "feature_id": 872,
+            "source_id": 172,
             "feature_display": "BRCA1 (Pathogenic)"
         },
         {
@@ -30086,6 +32702,9 @@
             "publication_date": "2023-03-11",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 873,
+            "feature_id": 873,
+            "source_id": 172,
             "feature_display": "BRCA2 (Pathogenic)"
         },
         {
@@ -30123,6 +32742,9 @@
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 874,
+            "feature_id": 874,
+            "source_id": 260,
             "feature_display": "ATM"
         },
         {
@@ -30160,6 +32782,9 @@
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 875,
+            "feature_id": 875,
+            "source_id": 260,
             "feature_display": "ATR"
         },
         {
@@ -30197,6 +32822,9 @@
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 876,
+            "feature_id": 876,
+            "source_id": 260,
             "feature_display": "BRCA1"
         },
         {
@@ -30234,6 +32862,9 @@
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 877,
+            "feature_id": 877,
+            "source_id": 260,
             "feature_display": "BRCA2"
         },
         {
@@ -30271,6 +32902,9 @@
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 878,
+            "feature_id": 878,
+            "source_id": 260,
             "feature_display": "CDK12"
         },
         {
@@ -30308,6 +32942,9 @@
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 879,
+            "feature_id": 879,
+            "source_id": 260,
             "feature_display": "CHEK2"
         },
         {
@@ -30345,6 +32982,9 @@
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 880,
+            "feature_id": 880,
+            "source_id": 260,
             "feature_display": "FANCA"
         },
         {
@@ -30382,6 +33022,9 @@
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 881,
+            "feature_id": 881,
+            "source_id": 260,
             "feature_display": "MLH1"
         },
         {
@@ -30418,7 +33061,10 @@
             "nct": "",
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
-            "_deprecated": true
+            "_deprecated": true,
+            "assertion_id": 882,
+            "feature_id": 882,
+            "source_id": 260
         },
         {
             "feature_type": "Somatic Variant",
@@ -30455,6 +33101,9 @@
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 883,
+            "feature_id": 883,
+            "source_id": 260,
             "feature_display": "NBN"
         },
         {
@@ -30492,6 +33141,9 @@
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 884,
+            "feature_id": 884,
+            "source_id": 260,
             "feature_display": "PALB2"
         },
         {
@@ -30529,6 +33181,9 @@
             "publication_date": "2023-06-20",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 885,
+            "feature_id": 885,
+            "source_id": 260,
             "feature_display": "RAD51C"
         },
         {
@@ -30567,6 +33222,9 @@
             "publication_date": "2023-08-11",
             "last_updated": "2023-09-06",
             "_deprecated": false,
+            "assertion_id": 886,
+            "feature_id": 886,
+            "source_id": 261,
             "feature_display": "BRCA1"
         },
         {
@@ -30604,6 +33262,9 @@
             "publication_date": "2023-08-11",
             "last_updated": "2023-09-06",
             "_deprecated": false,
+            "assertion_id": 887,
+            "feature_id": 887,
+            "source_id": 261,
             "feature_display": "BRCA1"
         },
         {
@@ -30642,6 +33303,9 @@
             "publication_date": "2023-08-11",
             "last_updated": "2023-09-06",
             "_deprecated": false,
+            "assertion_id": 888,
+            "feature_id": 888,
+            "source_id": 261,
             "feature_display": "BRCA2"
         },
         {
@@ -30679,6 +33343,9 @@
             "publication_date": "2023-08-11",
             "last_updated": "2023-09-06",
             "_deprecated": false,
+            "assertion_id": 889,
+            "feature_id": 889,
+            "source_id": 261,
             "feature_display": "BRCA2"
         },
         {
@@ -30705,6 +33372,9 @@
             "publication_date": "2023-07-31",
             "last_updated": "2023-09-06",
             "_deprecated": false,
+            "assertion_id": 890,
+            "feature_id": 890,
+            "source_id": 262,
             "feature_display": "MSI-High"
         },
         {
@@ -30742,6 +33412,9 @@
             "publication_date": "2019-01-22",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 891,
+            "feature_id": 891,
+            "source_id": 263,
             "feature_display": "TP53"
         },
         {
@@ -30774,11 +33447,14 @@
             "citation": "Holme H, Gulati A, Brough R, et al. Chemosensitivity profiling of osteosarcoma tumour cell lines identifies a model of BRCAness. Sci Rep. 2018;8(1).",
             "url": "https://www.nature.com/articles/s41598-018-29043-z",
             "doi": "10.1038/s41598-018-29043-z",
-            "pmid": "30006631",
+            "pmid": 30006631,
             "nct": "",
             "publication_date": "2018-07-13",
-            "last_updated": "2023-07-06",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 892,
+            "feature_id": 892,
+            "source_id": 264,
             "feature_display": "RB1"
         },
         {
@@ -30803,11 +33479,14 @@
             "citation": "Holme H, Gulati A, Brough R, et al. Chemosensitivity profiling of osteosarcoma tumour cell lines identifies a model of BRCAness. Sci Rep. 2018;8(1).",
             "url": "https://www.nature.com/articles/s41598-018-29043-z",
             "doi": "10.1038/s41598-018-29043-z",
-            "pmid": "30006631",
+            "pmid": 30006631,
             "nct": "",
             "publication_date": "2018-07-13",
-            "last_updated": "2023-07-06",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 893,
+            "feature_id": 893,
+            "source_id": 264,
             "feature_display": "FGFR1 Amplification"
         },
         {
@@ -30832,11 +33511,14 @@
             "citation": "Holme H, Gulati A, Brough R, et al. Chemosensitivity profiling of osteosarcoma tumour cell lines identifies a model of BRCAness. Sci Rep. 2018;8(1).",
             "url": "https://www.nature.com/articles/s41598-018-29043-z",
             "doi": "10.1038/s41598-018-29043-z",
-            "pmid": "30006631",
+            "pmid": 30006631,
             "nct": "",
             "publication_date": "2018-07-13",
-            "last_updated": "2023-07-06",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 894,
+            "feature_id": 894,
+            "source_id": 264,
             "feature_display": "FGFR1 Amplification"
         },
         {
@@ -30869,11 +33551,14 @@
             "citation": "Zoumpoulidou G, Alvarez-Mendoza C, Mancusi C, et al. Therapeutic vulnerability to PARP1,2 inhibition in RB1-mutant osteosarcoma. Nat Commun. 2021;12(1).",
             "url": "https://www.nature.com/articles/s41467-021-27291-8",
             "doi": "10.1038/s41467-021-27291-8",
-            "pmid": "34862364",
+            "pmid": 34862364,
             "nct": "",
             "publication_date": "2021-12-03",
-            "last_updated": "2023-07-06",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 895,
+            "feature_id": 895,
+            "source_id": 265,
             "feature_display": "RB1"
         },
         {
@@ -30903,6 +33588,9 @@
             "publication_date": "2019-01-09",
             "last_updated": "2023-07-06",
             "_deprecated": false,
+            "assertion_id": 896,
+            "feature_id": 896,
+            "source_id": 266,
             "feature_display": "MYC Amplification"
         },
         {
@@ -30927,11 +33615,14 @@
             "citation": "Sayles LC, Breese MR, Koehne AL, et al. Genome-Informed Targeted Therapy for Osteosarcoma. Cancer Discovery. 2019;9(1):46-63.",
             "url": "https://aacrjournals.org/cancerdiscovery/article/9/1/46/10398/Genome-Informed-Targeted-Therapy-for",
             "doi": "10.1158/2159-8290.CD-17-1152",
-            "pmid": "30266815",
+            "pmid": 30266815,
             "nct": "",
             "publication_date": "2019-01-09",
-            "last_updated": "2023-07-06",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 897,
+            "feature_id": 897,
+            "source_id": 266,
             "feature_display": "CCNE1 Amplification"
         },
         {
@@ -30956,11 +33647,14 @@
             "citation": "Sayles LC, Breese MR, Koehne AL, et al. Genome-Informed Targeted Therapy for Osteosarcoma. Cancer Discovery. 2019;9(1):46-63.",
             "url": "https://aacrjournals.org/cancerdiscovery/article/9/1/46/10398/Genome-Informed-Targeted-Therapy-for",
             "doi": "10.1158/2159-8290.CD-17-1152",
-            "pmid": "30266815",
+            "pmid": 30266815,
             "nct": "",
             "publication_date": "2019-01-09",
-            "last_updated": "2023-07-06",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 898,
+            "feature_id": 898,
+            "source_id": 266,
             "feature_display": "CDK4 Amplification"
         },
         {
@@ -30985,11 +33679,14 @@
             "citation": "Sayles LC, Breese MR, Koehne AL, et al. Genome-Informed Targeted Therapy for Osteosarcoma. Cancer Discovery. 2019;9(1):46-63.",
             "url": "https://aacrjournals.org/cancerdiscovery/article/9/1/46/10398/Genome-Informed-Targeted-Therapy-for",
             "doi": "10.1158/2159-8290.CD-17-1152",
-            "pmid": "30266815",
+            "pmid": 30266815,
             "nct": "",
             "publication_date": "2019-01-09",
-            "last_updated": "2023-07-06",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 899,
+            "feature_id": 899,
+            "source_id": 266,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -31014,11 +33711,14 @@
             "citation": "Sayles LC, Breese MR, Koehne AL, et al. Genome-Informed Targeted Therapy for Osteosarcoma. Cancer Discovery. 2019;9(1):46-63.",
             "url": "https://aacrjournals.org/cancerdiscovery/article/9/1/46/10398/Genome-Informed-Targeted-Therapy-for",
             "doi": "10.1158/2159-8290.CD-17-1152",
-            "pmid": "30266815",
+            "pmid": 30266815,
             "nct": "",
             "publication_date": "2019-01-09",
-            "last_updated": "2023-07-06",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 900,
+            "feature_id": 900,
+            "source_id": 266,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -31043,11 +33743,14 @@
             "citation": "Engert F, Kovac M, Baumhoer D, Nathrath M, Fulda S. Osteosarcoma cells with genetic signatures of BRCAness are susceptible to the PARP inhibitor talazoparib alone or in combination with chemotherapeutics. Oncotarget. 2016;8(30):48794-48806.",
             "url": "https://www.clinicalkey.com/#!/content/playContent/1-s2.0-S1470204513700494",
             "doi": "10.18632/oncotarget.10720",
-            "pmid": "27447864",
+            "pmid": 27447864,
             "nct": "",
             "publication_date": "2017-07-25",
-            "last_updated": "2023-07-27",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 901,
+            "feature_id": 901,
+            "source_id": 267,
             "feature_display": "BAP1 Deletion"
         },
         {
@@ -31072,11 +33775,14 @@
             "citation": "Engert F, Kovac M, Baumhoer D, Nathrath M, Fulda S. Osteosarcoma cells with genetic signatures of BRCAness are susceptible to the PARP inhibitor talazoparib alone or in combination with chemotherapeutics. Oncotarget. 2016;8(30):48794-48806.",
             "url": "https://www.clinicalkey.com/#!/content/playContent/1-s2.0-S1470204513700494",
             "doi": "10.18632/oncotarget.10720",
-            "pmid": "27447864",
+            "pmid": 27447864,
             "nct": "",
             "publication_date": "2017-07-25",
-            "last_updated": "2023-07-27",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 902,
+            "feature_id": 902,
+            "source_id": 267,
             "feature_display": "FANCA Deletion"
         },
         {
@@ -31101,11 +33807,14 @@
             "citation": "Engert F, Kovac M, Baumhoer D, Nathrath M, Fulda S. Osteosarcoma cells with genetic signatures of BRCAness are susceptible to the PARP inhibitor talazoparib alone or in combination with chemotherapeutics. Oncotarget. 2016;8(30):48794-48806.",
             "url": "https://www.clinicalkey.com/#!/content/playContent/1-s2.0-S1470204513700494",
             "doi": "10.18632/oncotarget.10720",
-            "pmid": "27447864",
+            "pmid": 27447864,
             "nct": "",
             "publication_date": "2017-07-25",
-            "last_updated": "2023-07-27",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 903,
+            "feature_id": 903,
+            "source_id": 267,
             "feature_display": "BARD1 Deletion"
         },
         {
@@ -31130,11 +33839,14 @@
             "citation": "Engert F, Kovac M, Baumhoer D, Nathrath M, Fulda S. Osteosarcoma cells with genetic signatures of BRCAness are susceptible to the PARP inhibitor talazoparib alone or in combination with chemotherapeutics. Oncotarget. 2016;8(30):48794-48806.",
             "url": "https://www.clinicalkey.com/#!/content/playContent/1-s2.0-S1470204513700494",
             "doi": "10.18632/oncotarget.10720",
-            "pmid": "27447864",
+            "pmid": 27447864,
             "nct": "",
             "publication_date": "2017-07-25",
-            "last_updated": "2023-07-27",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 904,
+            "feature_id": 904,
+            "source_id": 267,
             "feature_display": "CHEK2 Deletion"
         },
         {
@@ -31159,11 +33871,14 @@
             "citation": "Engert F, Kovac M, Baumhoer D, Nathrath M, Fulda S. Osteosarcoma cells with genetic signatures of BRCAness are susceptible to the PARP inhibitor talazoparib alone or in combination with chemotherapeutics. Oncotarget. 2016;8(30):48794-48806.",
             "url": "https://www.clinicalkey.com/#!/content/playContent/1-s2.0-S1470204513700494",
             "doi": "10.18632/oncotarget.10720",
-            "pmid": "27447864",
+            "pmid": 27447864,
             "nct": "",
             "publication_date": "2017-07-25",
-            "last_updated": "2023-07-27",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 905,
+            "feature_id": 905,
+            "source_id": 267,
             "feature_display": "TP53 Deletion"
         },
         {
@@ -31188,11 +33903,14 @@
             "citation": "Engert F, Kovac M, Baumhoer D, Nathrath M, Fulda S. Osteosarcoma cells with genetic signatures of BRCAness are susceptible to the PARP inhibitor talazoparib alone or in combination with chemotherapeutics. Oncotarget. 2016;8(30):48794-48806.",
             "url": "https://www.clinicalkey.com/#!/content/playContent/1-s2.0-S1470204513700494",
             "doi": "10.18632/oncotarget.10720",
-            "pmid": "27447864",
+            "pmid": 27447864,
             "nct": "",
             "publication_date": "2017-07-25",
-            "last_updated": "2023-07-27",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 906,
+            "feature_id": 906,
+            "source_id": 267,
             "feature_display": "ATM Deletion"
         },
         {
@@ -31223,6 +33941,9 @@
             "publication_date": "2023-09-26",
             "last_updated": "2023-11-01",
             "_deprecated": false,
+            "assertion_id": 907,
+            "feature_id": 907,
+            "source_id": 268,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -31259,6 +33980,9 @@
             "publication_date": "2023-10-24",
             "last_updated": "2023-11-01",
             "_deprecated": false,
+            "assertion_id": 908,
+            "feature_id": 908,
+            "source_id": 269,
             "feature_display": "IDH1"
         },
         {
@@ -31295,6 +34019,9 @@
             "publication_date": "2023-10-24",
             "last_updated": "2023-11-01",
             "_deprecated": false,
+            "assertion_id": 909,
+            "feature_id": 909,
+            "source_id": 269,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -31331,6 +34058,9 @@
             "publication_date": "2023-10-24",
             "last_updated": "2023-11-01",
             "_deprecated": false,
+            "assertion_id": 910,
+            "feature_id": 910,
+            "source_id": 269,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -31367,6 +34097,9 @@
             "publication_date": "2023-10-11",
             "last_updated": "2023-11-01",
             "_deprecated": false,
+            "assertion_id": 911,
+            "feature_id": 911,
+            "source_id": 270,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -31403,6 +34136,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 912,
+            "feature_id": 912,
+            "source_id": 33,
             "feature_display": "FLT3 p.D835A (Missense)"
         },
         {
@@ -31439,6 +34175,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 913,
+            "feature_id": 913,
+            "source_id": 33,
             "feature_display": "FLT3 p.D835E (Missense)"
         },
         {
@@ -31475,6 +34214,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 914,
+            "feature_id": 914,
+            "source_id": 33,
             "feature_display": "FLT3 p.D835H (Missense)"
         },
         {
@@ -31511,6 +34253,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 915,
+            "feature_id": 915,
+            "source_id": 33,
             "feature_display": "FLT3 p.D835Y (Missense)"
         },
         {
@@ -31547,6 +34292,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 916,
+            "feature_id": 916,
+            "source_id": 33,
             "feature_display": "FLT3 (Missense)"
         },
         {
@@ -31583,6 +34331,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 917,
+            "feature_id": 917,
+            "source_id": 33,
             "feature_display": "FLT3 (Nonsense)"
         },
         {
@@ -31619,6 +34370,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 918,
+            "feature_id": 918,
+            "source_id": 33,
             "feature_display": "FLT3 (Frameshift)"
         },
         {
@@ -31655,6 +34409,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 919,
+            "feature_id": 919,
+            "source_id": 33,
             "feature_display": "FLT3 (Splice Site)"
         },
         {
@@ -31691,6 +34448,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-03",
             "_deprecated": false,
+            "assertion_id": 920,
+            "feature_id": 920,
+            "source_id": 33,
             "feature_display": "NPM1 p.W288Cfs*12 (Frameshift)"
         },
         {
@@ -31727,6 +34487,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-06",
             "_deprecated": false,
+            "assertion_id": 921,
+            "feature_id": 921,
+            "source_id": 33,
             "feature_display": "SRSF2 p.P95H (Missense)"
         },
         {
@@ -31763,6 +34526,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-06",
             "_deprecated": false,
+            "assertion_id": 922,
+            "feature_id": 922,
+            "source_id": 33,
             "feature_display": "SRSF2 p.P95L (Missense)"
         },
         {
@@ -31799,6 +34565,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-06",
             "_deprecated": false,
+            "assertion_id": 923,
+            "feature_id": 923,
+            "source_id": 33,
             "feature_display": "SRSF2 p.P95R (Missense)"
         },
         {
@@ -31835,6 +34604,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-06",
             "_deprecated": false,
+            "assertion_id": 924,
+            "feature_id": 924,
+            "source_id": 33,
             "feature_display": "SRSF2 p.P95A (Missense)"
         },
         {
@@ -31871,6 +34643,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-06",
             "_deprecated": false,
+            "assertion_id": 925,
+            "feature_id": 925,
+            "source_id": 33,
             "feature_display": "SRSF2 p.P95_R102del (Deletion)"
         },
         {
@@ -31907,6 +34682,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 926,
+            "feature_id": 926,
+            "source_id": 33,
             "feature_display": "WT1 (Nonsense)"
         },
         {
@@ -31943,6 +34721,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 927,
+            "feature_id": 927,
+            "source_id": 33,
             "feature_display": "WT1 (Frameshift)"
         },
         {
@@ -31979,6 +34760,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 928,
+            "feature_id": 928,
+            "source_id": 33,
             "feature_display": "WT1 (Splice Site)"
         },
         {
@@ -32015,6 +34799,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 929,
+            "feature_id": 929,
+            "source_id": 33,
             "feature_display": "U2AF1 p.S34A (Missense)"
         },
         {
@@ -32051,6 +34838,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 930,
+            "feature_id": 930,
+            "source_id": 33,
             "feature_display": "U2AF1 p.S34F (Missense)"
         },
         {
@@ -32087,6 +34877,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 931,
+            "feature_id": 931,
+            "source_id": 33,
             "feature_display": "U2AF1 p.S34F (Missense)"
         },
         {
@@ -32123,6 +34916,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 932,
+            "feature_id": 932,
+            "source_id": 33,
             "feature_display": "U2AF1 p.S34Y (Missense)"
         },
         {
@@ -32159,6 +34955,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 933,
+            "feature_id": 933,
+            "source_id": 33,
             "feature_display": "U2AF1 p.Q157P (Missense)"
         },
         {
@@ -32195,6 +34994,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 934,
+            "feature_id": 934,
+            "source_id": 33,
             "feature_display": "U2AF1 p.Q157P (Missense)"
         },
         {
@@ -32231,6 +35033,9 @@
             "publication_date": "2023-10-17",
             "last_updated": "2023-11-02",
             "_deprecated": false,
+            "assertion_id": 935,
+            "feature_id": 935,
+            "source_id": 33,
             "feature_display": "U2AF1 p.Q157R (Missense)"
         },
         {
@@ -32259,7 +35064,10 @@
             "nct": "",
             "publication_date": "2023-11-15",
             "last_updated": "2023-12-05",
-            "_deprecated": true
+            "_deprecated": true,
+            "assertion_id": 936,
+            "feature_id": 936,
+            "source_id": 271
         },
         {
             "feature_type": "Somatic Variant",
@@ -32295,6 +35103,9 @@
             "publication_date": "2023-11-16",
             "last_updated": "2023-12-07",
             "_deprecated": false,
+            "assertion_id": 937,
+            "feature_id": 937,
+            "source_id": 272,
             "feature_display": "PIK3CA"
         },
         {
@@ -32331,6 +35142,9 @@
             "publication_date": "2023-11-16",
             "last_updated": "2023-12-07",
             "_deprecated": false,
+            "assertion_id": 938,
+            "feature_id": 938,
+            "source_id": 272,
             "feature_display": "AKT1"
         },
         {
@@ -32367,6 +35181,9 @@
             "publication_date": "2023-11-16",
             "last_updated": "2023-12-07",
             "_deprecated": false,
+            "assertion_id": 939,
+            "feature_id": 939,
+            "source_id": 272,
             "feature_display": "PTEN (Nonsense)"
         },
         {
@@ -32403,6 +35220,9 @@
             "publication_date": "2023-11-16",
             "last_updated": "2023-12-07",
             "_deprecated": false,
+            "assertion_id": 940,
+            "feature_id": 940,
+            "source_id": 272,
             "feature_display": "PTEN (Frameshift)"
         },
         {
@@ -32439,6 +35259,9 @@
             "publication_date": "2023-11-16",
             "last_updated": "2023-12-07",
             "_deprecated": false,
+            "assertion_id": 941,
+            "feature_id": 941,
+            "source_id": 272,
             "feature_display": "PTEN (Splice Site)"
         },
         {
@@ -32467,6 +35290,9 @@
             "publication_date": "2023-11-16",
             "last_updated": "2023-12-07",
             "_deprecated": false,
+            "assertion_id": 942,
+            "feature_id": 942,
+            "source_id": 272,
             "feature_display": "PTEN Deletion"
         },
         {
@@ -32488,13 +35314,16 @@
             "description": "The U.S. Food and Drug Administration (FDA) approved neratinib in combination with capecitabine for the treatment of adult patients with advanced or metastatic HER2-positive breast cancer who have received two or more prior anti-HER2 based regimens in the metastatic setting.",
             "source_type": "FDA",
             "citation": "Puma Biotechnology, Inc. Nerlynx (neratinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/208051s009lbl.pdf. Revised June 2021. Accessed January 11, 2024.",
-            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/210868s001lbl.pdf",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/208051s009lbl.pdf",
             "doi": "",
             "pmid": "",
             "nct": "",
             "publication_date": "2020-02-25",
-            "last_updated": "2024-01-11",
+            "last_updated": "2025-01-08",
             "_deprecated": false,
+            "assertion_id": 943,
+            "feature_id": 943,
+            "source_id": 202,
             "feature_display": "ERBB2 Amplification"
         },
         {
@@ -32531,6 +35360,9 @@
             "publication_date": "2017-11-06",
             "last_updated": "2024-01-30",
             "_deprecated": false,
+            "assertion_id": 944,
+            "feature_id": 944,
+            "source_id": 273,
             "feature_display": "BRAF p.V600E (Missense)"
         },
         {
@@ -32567,6 +35399,9 @@
             "publication_date": "2017-11-06",
             "last_updated": "2024-01-30",
             "_deprecated": false,
+            "assertion_id": 945,
+            "feature_id": 945,
+            "source_id": 273,
             "feature_display": "BRAF p.V600K (Missense)"
         },
         {
@@ -32603,6 +35438,9 @@
             "publication_date": "2024-03-01",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 946,
+            "feature_id": 946,
+            "source_id": 274,
             "feature_display": "EGFR Exon 20 (Insertion)"
         },
         {
@@ -32639,6 +35477,9 @@
             "publication_date": "2024-02-16",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 947,
+            "feature_id": 947,
+            "source_id": 275,
             "feature_display": "EGFR Exon 19 (Deletion)"
         },
         {
@@ -32675,6 +35516,9 @@
             "publication_date": "2024-02-16",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 948,
+            "feature_id": 948,
+            "source_id": 275,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -32711,6 +35555,9 @@
             "publication_date": "2018-04-18",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 949,
+            "feature_id": 949,
+            "source_id": 276,
             "feature_display": "EGFR Exon 19 (Deletion)"
         },
         {
@@ -32747,6 +35594,9 @@
             "publication_date": "2018-04-18",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 950,
+            "feature_id": 950,
+            "source_id": 276,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -32783,6 +35633,9 @@
             "publication_date": "2024-02-15",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 951,
+            "feature_id": 951,
+            "source_id": 277,
             "feature_display": "MET Exon 14 (Splice Site)"
         },
         {
@@ -32819,6 +35672,9 @@
             "publication_date": "2024-02-15",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 952,
+            "feature_id": 952,
+            "source_id": 277,
             "feature_display": "MET Exon 14 (Deletion)"
         },
         {
@@ -32848,6 +35704,9 @@
             "publication_date": "2021-01-14",
             "last_updated": "2024-03-04",
             "_deprecated": false,
+            "assertion_id": 953,
+            "feature_id": 953,
+            "source_id": 278,
             "feature_display": "ALK Fusion"
         },
         {
@@ -32877,6 +35736,9 @@
             "publication_date": "2019-08-01",
             "last_updated": "2024-04-11",
             "_deprecated": false,
+            "assertion_id": 954,
+            "feature_id": 954,
+            "source_id": 40,
             "feature_display": "ROS1 Fusion"
         },
         {
@@ -32906,6 +35768,9 @@
             "publication_date": "2023-11-15",
             "last_updated": "2024-04-11",
             "_deprecated": false,
+            "assertion_id": 955,
+            "feature_id": 955,
+            "source_id": 271,
             "feature_display": "ROS1"
         },
         {
@@ -32943,6 +35808,9 @@
             "publication_date": "2023-06-20",
             "last_updated": "2024-04-11",
             "_deprecated": false,
+            "assertion_id": 956,
+            "feature_id": 956,
+            "source_id": 260,
             "feature_display": "MRE11"
         },
         {
@@ -32973,6 +35841,9 @@
             "publication_date": "2024-03-19",
             "last_updated": "2024-04-11",
             "_deprecated": false,
+            "assertion_id": 957,
+            "feature_id": 957,
+            "source_id": 279,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -33003,6 +35874,9 @@
             "publication_date": "2013-12-20",
             "last_updated": "2024-04-11",
             "_deprecated": false,
+            "assertion_id": 958,
+            "feature_id": 958,
+            "source_id": 280,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -33033,6 +35907,9 @@
             "publication_date": "2013-12-20",
             "last_updated": "2024-04-11",
             "_deprecated": false,
+            "assertion_id": 959,
+            "feature_id": 959,
+            "source_id": 280,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -33070,6 +35947,9 @@
             "publication_date": "2013-12-20",
             "last_updated": "2024-04-11",
             "_deprecated": false,
+            "assertion_id": 960,
+            "feature_id": 960,
+            "source_id": 280,
             "feature_display": "ABL1 p.T315I (Missense)"
         },
         {
@@ -33107,6 +35987,9 @@
             "publication_date": "2013-12-20",
             "last_updated": "2024-04-11",
             "_deprecated": false,
+            "assertion_id": 961,
+            "feature_id": 961,
+            "source_id": 280,
             "feature_display": "ABL1 p.T315I (Missense)"
         },
         {
@@ -33136,6 +36019,9 @@
             "publication_date": "2024-04-18",
             "last_updated": "2024-06-03",
             "_deprecated": false,
+            "assertion_id": 962,
+            "feature_id": 962,
+            "source_id": 281,
             "feature_display": "ALK Fusion"
         },
         {
@@ -33172,6 +36058,9 @@
             "publication_date": "2024-04-23",
             "last_updated": "2024-06-03",
             "_deprecated": false,
+            "assertion_id": 963,
+            "feature_id": 963,
+            "source_id": 282,
             "feature_display": "BRAF p.V600K (Missense)"
         },
         {
@@ -33201,6 +36090,9 @@
             "publication_date": "2024-04-23",
             "last_updated": "2024-06-03",
             "_deprecated": false,
+            "assertion_id": 964,
+            "feature_id": 964,
+            "source_id": 282,
             "feature_display": "BRAF"
         },
         {
@@ -33230,6 +36122,9 @@
             "publication_date": "2024-04-23",
             "last_updated": "2024-06-03",
             "_deprecated": false,
+            "assertion_id": 965,
+            "feature_id": 965,
+            "source_id": 282,
             "feature_display": "BRAF Fusion"
         },
         {
@@ -33266,6 +36161,9 @@
             "publication_date": "2016-10-18",
             "last_updated": "2024-06-03",
             "_deprecated": false,
+            "assertion_id": 966,
+            "feature_id": 966,
+            "source_id": 283,
             "feature_display": "EGFR Exon 19 (Deletion)"
         },
         {
@@ -33302,6 +36200,9 @@
             "publication_date": "2016-10-18",
             "last_updated": "2024-06-03",
             "_deprecated": false,
+            "assertion_id": 967,
+            "feature_id": 967,
+            "source_id": 283,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -33338,6 +36239,9 @@
             "publication_date": "2021-05-05",
             "last_updated": "2024-06-03",
             "_deprecated": false,
+            "assertion_id": 968,
+            "feature_id": 968,
+            "source_id": 284,
             "feature_display": "EGFR Exon 19 (Deletion)"
         },
         {
@@ -33374,6 +36278,9 @@
             "publication_date": "2021-05-05",
             "last_updated": "2024-06-03",
             "_deprecated": false,
+            "assertion_id": 969,
+            "feature_id": 969,
+            "source_id": 284,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -33403,6 +36310,9 @@
             "publication_date": "2024-06-13",
             "last_updated": "2024-07-11",
             "_deprecated": false,
+            "assertion_id": 970,
+            "feature_id": 970,
+            "source_id": 285,
             "feature_display": "NTRK1 Fusion"
         },
         {
@@ -33432,6 +36342,9 @@
             "publication_date": "2024-06-13",
             "last_updated": "2024-07-11",
             "_deprecated": false,
+            "assertion_id": 971,
+            "feature_id": 971,
+            "source_id": 285,
             "feature_display": "NTRK2 Fusion"
         },
         {
@@ -33461,6 +36374,9 @@
             "publication_date": "2024-06-13",
             "last_updated": "2024-07-11",
             "_deprecated": false,
+            "assertion_id": 972,
+            "feature_id": 972,
+            "source_id": 285,
             "feature_display": "NTRK3 Fusion"
         },
         {
@@ -33497,6 +36413,9 @@
             "publication_date": "2024-06-21",
             "last_updated": "2024-07-11",
             "_deprecated": false,
+            "assertion_id": 973,
+            "feature_id": 973,
+            "source_id": 286,
             "feature_display": "KRAS p.G12C (Missense)"
         },
         {
@@ -33533,6 +36452,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 974,
+            "feature_id": 974,
+            "source_id": 287,
             "feature_display": "IDH1"
         },
         {
@@ -33569,6 +36491,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 975,
+            "feature_id": 975,
+            "source_id": 287,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -33605,6 +36530,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 976,
+            "feature_id": 976,
+            "source_id": 287,
             "feature_display": "IDH1 p.R132G (Missense)"
         },
         {
@@ -33641,6 +36569,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 977,
+            "feature_id": 977,
+            "source_id": 287,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -33677,6 +36608,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 978,
+            "feature_id": 978,
+            "source_id": 287,
             "feature_display": "IDH1 p.R132L (Missense)"
         },
         {
@@ -33713,6 +36647,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 979,
+            "feature_id": 979,
+            "source_id": 287,
             "feature_display": "IDH1 p.R132S (Missense)"
         },
         {
@@ -33749,6 +36686,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 980,
+            "feature_id": 980,
+            "source_id": 287,
             "feature_display": "IDH2"
         },
         {
@@ -33785,6 +36725,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 981,
+            "feature_id": 981,
+            "source_id": 287,
             "feature_display": "IDH2 p.R172K (Missense)"
         },
         {
@@ -33821,6 +36764,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 982,
+            "feature_id": 982,
+            "source_id": 287,
             "feature_display": "IDH2 p.R172G (Missense)"
         },
         {
@@ -33857,6 +36803,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 983,
+            "feature_id": 983,
+            "source_id": 287,
             "feature_display": "IDH1"
         },
         {
@@ -33893,6 +36842,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 984,
+            "feature_id": 984,
+            "source_id": 287,
             "feature_display": "IDH1 p.R132C (Missense)"
         },
         {
@@ -33929,6 +36881,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 985,
+            "feature_id": 985,
+            "source_id": 287,
             "feature_display": "IDH1 p.R132G (Missense)"
         },
         {
@@ -33965,6 +36920,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 986,
+            "feature_id": 986,
+            "source_id": 287,
             "feature_display": "IDH1 p.R132H (Missense)"
         },
         {
@@ -34001,6 +36959,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 987,
+            "feature_id": 987,
+            "source_id": 287,
             "feature_display": "IDH1 p.R132L (Missense)"
         },
         {
@@ -34037,6 +36998,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 988,
+            "feature_id": 988,
+            "source_id": 287,
             "feature_display": "IDH1 p.R132S (Missense)"
         },
         {
@@ -34073,6 +37037,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 989,
+            "feature_id": 989,
+            "source_id": 287,
             "feature_display": "IDH2"
         },
         {
@@ -34109,6 +37076,9 @@
             "publication_date": "2024-08-06",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 990,
+            "feature_id": 990,
+            "source_id": 287,
             "feature_display": "IDH2 p.R172K (Missense)"
         },
         {
@@ -34145,6 +37115,9 @@
             "publication_date": "2024-08-19",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 991,
+            "feature_id": 991,
+            "source_id": 288,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -34181,6 +37154,9 @@
             "publication_date": "2024-08-19",
             "last_updated": "2024-09-03",
             "_deprecated": false,
+            "assertion_id": 992,
+            "feature_id": 992,
+            "source_id": 288,
             "feature_display": "EGFR Exon 19 (Deletion)"
         },
         {
@@ -34217,6 +37193,9 @@
             "publication_date": "2024-09-19",
             "last_updated": "2024-10-02",
             "_deprecated": false,
+            "assertion_id": 993,
+            "feature_id": 993,
+            "source_id": 289,
             "feature_display": "EGFR p.L858R (Missense)"
         },
         {
@@ -34253,6 +37232,9 @@
             "publication_date": "2024-09-19",
             "last_updated": "2024-10-02",
             "_deprecated": false,
+            "assertion_id": 994,
+            "feature_id": 994,
+            "source_id": 289,
             "feature_display": "EGFR Exon 19 (Deletion)"
         },
         {
@@ -34289,6 +37271,9 @@
             "publication_date": "2024-09-25",
             "last_updated": "2024-10-02",
             "_deprecated": false,
+            "assertion_id": 995,
+            "feature_id": 995,
+            "source_id": 290,
             "feature_display": "EGFR Exon 19 (Deletion)"
         },
         {
@@ -34325,6 +37310,9 @@
             "publication_date": "2024-09-25",
             "last_updated": "2024-10-02",
             "_deprecated": false,
+            "assertion_id": 996,
+            "feature_id": 996,
+            "source_id": 290,
             "feature_display": "EGFR p.T790M (Missense)"
         },
         {
@@ -34354,6 +37342,9 @@
             "publication_date": "2024-10-29",
             "last_updated": "2024-11-06",
             "_deprecated": false,
+            "assertion_id": 997,
+            "feature_id": 997,
+            "source_id": 6,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -34383,6 +37374,9 @@
             "publication_date": "2024-10-29",
             "last_updated": "2024-11-06",
             "_deprecated": false,
+            "assertion_id": 998,
+            "feature_id": 998,
+            "source_id": 6,
             "feature_display": "BCR--ABL1 Fusion"
         },
         {
@@ -34419,6 +37413,9 @@
             "publication_date": "2024-10-29",
             "last_updated": "2024-11-06",
             "_deprecated": false,
+            "assertion_id": 999,
+            "feature_id": 999,
+            "source_id": 6,
             "feature_display": "ABL1 p.T315I (Missense)"
         },
         {
@@ -34455,6 +37452,9 @@
             "publication_date": "2024-10-10",
             "last_updated": "2024-11-07",
             "_deprecated": false,
+            "assertion_id": 1000,
+            "feature_id": 1000,
+            "source_id": 291,
             "feature_display": "PIK3CA"
         },
         {
@@ -34484,6 +37484,9 @@
             "publication_date": "2024-11-15",
             "last_updated": "2024-12-05",
             "_deprecated": false,
+            "assertion_id": 1001,
+            "feature_id": 1001,
+            "source_id": 292,
             "feature_display": "KMT2A Translocation"
         },
         {
@@ -34513,6 +37516,9 @@
             "publication_date": "2024-11-15",
             "last_updated": "2024-12-05",
             "_deprecated": false,
+            "assertion_id": 1002,
+            "feature_id": 1002,
+            "source_id": 292,
             "feature_display": "KMT2A Translocation"
         },
         {
@@ -34542,6 +37548,9 @@
             "publication_date": "2024-12-04",
             "last_updated": "2024-12-05",
             "_deprecated": false,
+            "assertion_id": 1003,
+            "feature_id": 1003,
+            "source_id": 293,
             "feature_display": "NRG1 Fusion"
         },
         {
@@ -34571,7 +37580,120 @@
             "publication_date": "2024-12-04",
             "last_updated": "2024-12-05",
             "_deprecated": false,
+            "assertion_id": 1004,
+            "feature_id": 1004,
+            "source_id": 293,
             "feature_display": "NRG1 Fusion"
+        },
+        {
+            "feature_type": "Rearrangement",
+            "gene1": "ALK",
+            "gene2": "",
+            "rearrangement_type": "",
+            "locus": "",
+            "disease": "Non-Small Cell Lung Cancer",
+            "context": "Metastatic",
+            "oncotree_term": "Non-Small Cell Lung Cancer",
+            "oncotree_code": "NSCLC",
+            "therapy_name": "Ensartinib",
+            "therapy_strategy": "ALK inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted regular approval for ensartinib for the treatment of adult patients with anaplastic lymphoma kinase (ALK)-positive locally advanced or metastatic non-small cell lung cancer (NSCLC) who have not previously received an ALK inhibitor. The product label instructs to select patients based on the presence of ALK rearrangement(s) in tumor specimens, and states that an FDA-approved test to detect ALK rearrangements for selecting patients for treatment with ensartinib is not yet available.",
+            "source_type": "FDA",
+            "citation": "Xcovery Holdings, Inc. Ensacove (ensartinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/218171s000lbl.pdf. Revised December 2024. Accessed February 6, 2025.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/218171s000lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2024-12-18",
+            "last_updated": "2025-02-06",
+            "_deprecated": false,
+            "assertion_id": 1005,
+            "feature_id": 1005,
+            "source_id": 294,
+            "feature_display": "ALK"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "BRAF",
+            "chromosome": "7",
+            "start_position": 140453136,
+            "end_position": 140453136,
+            "reference_allele": "A",
+            "alternate_allele": "T",
+            "cdna_change": "c.1799T>A",
+            "protein_change": "p.V600E",
+            "variant_annotation": "Missense",
+            "exon": 15,
+            "rsid": "rs113488022",
+            "disease": "Colorectal Cancer",
+            "context": "Metastatic",
+            "oncotree_term": "Colorectal Adenocarcinoma",
+            "oncotree_code": "COADREAD",
+            "therapy_name": "Cetuximab + Encorafenib + Oxaplatin + 5-Fluorouracil",
+            "therapy_strategy": "EGFR inhibition + B-RAF inhibition + Platinum-based chemotherapy + Thymidylate synthase inhibition",
+            "therapy_type": "Combination therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to encorafenib in combination with cetuximab and mFOLFOX6 for the treatment of patients with metastatic colorectal cancer (mCRC) with a BRAF p.V600E variant, as detected by an FDA-approved test. mFOLFOX6 consists of oxaliplatin, folinic acid, and fluorouracil.",
+            "source_type": "FDA",
+            "citation": "Array BioPharma Inc. Braftovi (encorafenib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/210496s017lbl.pdf. Revised December 2024. Accessed February 6, 2025.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/210496s017lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2024-12-20",
+            "last_updated": "2025-02-06",
+            "_deprecated": false,
+            "assertion_id": 1006,
+            "feature_id": 1006,
+            "source_id": 295,
+            "feature_display": "BRAF p.V600E (Missense)"
+        },
+        {
+            "feature_type": "Somatic Variant",
+            "gene": "KRAS",
+            "chromosome": "12",
+            "start_position": 25398285,
+            "end_position": 25398285,
+            "reference_allele": "C",
+            "alternate_allele": "A",
+            "cdna_change": "c.34G>T",
+            "protein_change": "p.G12C",
+            "variant_annotation": "Missense",
+            "exon": 2,
+            "rsid": "rs121913530",
+            "disease": "Colorectal Cancer",
+            "context": "Metastatic",
+            "oncotree_term": "Colorectal Adenocarcinoma",
+            "oncotree_code": "COADREAD",
+            "therapy_name": "Panitumumab + Sotorasib",
+            "therapy_strategy": "EGFR inhibition + RAS inhibition",
+            "therapy_type": "Targeted therapy",
+            "therapy_sensitivity": 1,
+            "therapy_resistance": "",
+            "favorable_prognosis": "",
+            "predictive_implication": "FDA-Approved",
+            "description": "The U.S. Food and Drug Administration (FDA) has granted approval to panitumumab in combination with sotorasib for the treatment of adult patients with KRAS p.G12C-mutated metastatic colorectal cancer (mCRC), as determined by an FDA-approved test, who have received prior treatment with fluoropyrimidine-, oxaliplatin-, and irinotecan-based chemotherapy.",
+            "source_type": "FDA",
+            "citation": "Amgen Inc. Vectibix (panitumumab) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/125147s213lbl.pdf. Revised January 2025. Accessed February 6, 2025.",
+            "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/125147s213lbl.pdf",
+            "doi": "",
+            "pmid": "",
+            "nct": "",
+            "publication_date": "2025-01-16",
+            "last_updated": "2025-02-06",
+            "_deprecated": false,
+            "assertion_id": 1007,
+            "feature_id": 1007,
+            "source_id": 296,
+            "feature_display": "KRAS p.G12C (Missense)"
         }
     ]
 }

--- a/moalmanac/config.ini
+++ b/moalmanac/config.ini
@@ -14,7 +14,7 @@ level = INFO
 
 [versions]
 interpreter = 0.8.1
-database = v.2024-12-05
+database = v.2025-02-07
 
 [exac]
 exac_common_af_threshold = 0.001


### PR DESCRIPTION
The [underlying moalmanac database](https://github.com/vanallenlab/moalmanac/tree/main/datasources/moalmanac) was updated to the [2025-02-07 release](https://github.com/vanallenlab/moalmanac-db/releases/tag/v.2025-02-07). The docker was pushed to the [latest](https://hub.docker.com/repository/docker/vanallenlab/moalmanac/tags/latest/sha256-58a9f65b2a6aced91f1f4ad82612bf438ac2c6f4d6e85e3a3b6c0945ff20a77c) and [0.8.1_v.2025-02-07](https://hub.docker.com/repository/docker/vanallenlab/moalmanac/tags/0.8.1_v.2025-02-07/sha256-58a9f65b2a6aced91f1f4ad82612bf438ac2c6f4d6e85e3a3b6c0945ff20a77c) tags.

Revisions:
- The default value for the argument `--config` in `datasources/moalmanac/create_moalmanac_db.py` was updated to reflect the `datasources` folder now being located within the root directory of the repository.

Pre-pull request check list,
- [x] Relevant documentation has been updated
- [x] All unit tests pass
- [x] All outputs pre- and post- changes match by md5 hash
- [x] All files changed have been reviewed
- [x] Docker pushed

[2025-02-07-regression-tests-pre-post.zip](https://github.com/user-attachments/files/18702548/2025-02-07-regression-tests-pre-post.zip)