### PR TITLE
Support Python 3.13 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -337,3 +337,25 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
+
+---
+This repository contains code is adapted from the snfpy repository (moalmanac/snf.py, from https://github.com/rmarkello/snfpy/tree/master),
+which is licensed under the GNU Lesser General Public License v3.0 (LGPL-3.0). See snfpy_LICENSE.txt for the full text
+of the LGPL-3.0 license.
+
+That code is a translation of the original Similarity Network Fusion (SNF) code, implemented in R
+and matlab: http://compbio.cs.toronto.edu/SNF/SNF/Software.html
+
+If you use this portion of the code, please cite:
+
+Wang, B., Mezlini, A. M., Demir, F., Fiume, M., Tu, Z., Brudno, M., Haibe-Kains, B., &
+Goldenberg, A. (2014). Similarity network fusion for aggregating data types on a genomic scale.
+Nature Methods, 11(3), 333.
+
+
+That code is licensed under the GNU Lesser General Public License v3.0 (LGPL-3.0),
+and is used in accordance with its terms. See snfpy_LICENSE.txt for the full text
+of the LGPL-3.0 license.
+
+The rest of this repository is licensed under the GNU General Public License v2.0.
+

--- a/LICENSE_snfpy
+++ b/LICENSE_snfpy
@@ -1,0 +1,174 @@
+This file contains the license under which the original `snfpy` repository is released:
+
+    https://github.com/rmarkello/snfpy/tree/master
+
+The code was translated from original R/Matlab implementations of the Similarity Network Fusion (SNF) algorithm.
+
+License: GNU Lesser General Public License v3.0
+Full text follows:
+
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+
+This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+0. Additional Definitions.
+
+As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+"The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+1. Exception to Section 3 of the GNU GPL.
+
+You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+2. Conveying Modified Versions.
+
+If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+a) under this License, provided that you make a good faith effort to
+ensure that, in the event an Application does not supply the
+function or data, the facility still operates, and performs
+whatever part of its purpose remains meaningful, or
+
+b) under the GNU GPL, with none of the additional permissions of
+this License applicable to that copy.
+
+3. Object Code Incorporating Material from Library Header Files.
+
+The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+a) Give prominent notice with each copy of the object code that the
+Library is used in it and that the Library and its use are
+covered by this License.
+
+b) Accompany the object code with a copy of the GNU GPL and this license
+document.
+
+4. Combined Works.
+
+You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+a) Give prominent notice with each copy of the Combined Work that
+the Library is used in it and that the Library and its use are
+covered by this License.
+
+b) Accompany the Combined Work with a copy of the GNU GPL and this license
+document.
+
+c) For a Combined Work that displays copyright notices during
+execution, include the copyright notice for the Library among
+these notices, as well as a reference directing the user to the
+copies of the GNU GPL and this license document.
+
+d) Do one of the following:
+
+0) Convey the Minimal Corresponding Source under the terms of this
+License, and the Corresponding Application Code in a form
+suitable for, and under terms that permit, the user to
+recombine or relink the Application with a modified version of
+the Linked Version to produce a modified Combined Work, in the
+manner specified by section 6 of the GNU GPL for conveying
+Corresponding Source.
+
+1) Use a suitable shared library mechanism for linking with the
+Library.  A suitable mechanism is one that (a) uses at run time
+a copy of the Library already present on the user's computer
+system, and (b) will operate properly with a modified version
+of the Library that is interface-compatible with the Linked
+Version.
+
+e) Provide Installation Information, but only if you would otherwise
+be required to provide such information under section 6 of the
+GNU GPL, and only to the extent that such information is
+necessary to install and execute a modified version of the
+Combined Work produced by recombining or relinking the
+Application with a modified version of the Linked Version. (If
+you use option 4d0, the Installation Information must accompany
+the Minimal Corresponding Source and Corresponding Application
+Code. If you use option 4d1, you must provide the Installation
+Information in the manner specified by section 6 of the GNU GPL
+for conveying Corresponding Source.)
+
+5. Combined Libraries.
+
+You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+a) Accompany the combined library with a copy of the same work based
+on the Library, uncombined with any other library facilities,
+conveyed under the terms of this License.
+
+b) Give prominent notice with the combined library that part of it
+is a work based on the Library, and explaining where to find the
+accompanying uncombined form of the same work.
+
+6. Revised Versions of the GNU Lesser General Public License.
+
+The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+NOTICE
+
+This repository includes adapted code, located at moalmanac/snf.py, from:
+
+  - `snfpy` (https://github.com/rmarkello/snfpy/tree/master), licensed under LGPL-3.0.
+  - Original SNF implementation in R/Matlab (http://compbio.cs.toronto.edu/SNF/SNF/Software.html)
+
+Please cite the original SNF paper if using this functionality:
+
+  Wang, B., Mezlini, A. M., Demir, F., Fiume, M., Tu, Z., Brudno, M., Haibe-Kains, B., &
+  Goldenberg, A. (2014). Similarity network fusion for aggregating data types on a genomic scale.
+  *Nature Methods*, 11(3), 333.
+
+Modifications were made in 2025 by Van Allen lab, Dana-Farber Cancer Institute for compatibility with Python 3.12+.

--- a/moalmanac/config.ini
+++ b/moalmanac/config.ini
@@ -13,7 +13,7 @@ include_preclinical_efficacy_in_actionability_report = on
 level = INFO
 
 [versions]
-interpreter = 0.8.1
+interpreter = 0.8.2
 database = v.2025-02-07
 
 [exac]

--- a/moalmanac/matchmaker.py
+++ b/moalmanac/matchmaker.py
@@ -1,13 +1,16 @@
 import numpy as np
 import pandas as pd
-import snf
 from sklearn import metrics
+
+#import warnings
+#warnings.filterwarnings("ignore", message=".*force_all_finite.*")
 
 from annotator import Almanac as AnnotatorAlmanac
 from annotator import PreclinicalMatchmaking as AnnotatorPreclinicalMatchmaking
 from datasources import Almanac as DatasourceAlmanac
 from datasources import CancerGeneCensus as DatasourceCGC
 from datasources import Preclinical as DatasourcePreclinical
+from snf import SNF
 
 from config import COLNAMES
 
@@ -545,15 +548,18 @@ class SNFTypesCGCwithEvidence(Models):
         boolean_dataframe_1 = AlmanacFeatures.create_boolean_table(inputs, samples, almanac_subset)
 
         data = [
-            boolean_dataframe_variants.loc[samples, :].fillna(0),
-            boolean_dataframe_copy_numbers.loc[samples, :].fillna(0),
-            boolean_dataframe_fusions.loc[samples, :].fillna(0),
-            boolean_dataframe_1.loc[samples, :].fillna(0),
+            boolean_dataframe_variants.loc[samples, :],#.fillna(0),
+            boolean_dataframe_copy_numbers.loc[samples, :],#.fillna(0),
+            boolean_dataframe_fusions.loc[samples, :],#.fillna(0),
+            boolean_dataframe_1.loc[samples, :]#.fillna(0),
         ]
 
         np.random.seed(seed)
-        affinity_networks = snf.make_affinity(data, metric='jaccard', normalize=False, K=20, mu=0.5)
-        fused_network = snf.snf(affinity_networks, K=20)
+        print('Running make affinity')
+        affinity_networks = SNF.make_affinity(data, metric='jaccard', normalize=False, K=20, mu=0.5)
+        print('Fusing network')
+        fused_network = SNF.snf(affinity_networks, K=20)
+        print('Network fused')
         fused_dataframe = pd.DataFrame(fused_network, index=samples, columns=samples)
         distance_dataframe = pd.DataFrame(1, index=samples, columns=samples).subtract(fused_dataframe)
         stacked_dataframe = cls.stack_distances(distance_dataframe, cls.label)

--- a/moalmanac/matchmaker.py
+++ b/moalmanac/matchmaker.py
@@ -2,9 +2,6 @@ import numpy as np
 import pandas as pd
 from sklearn import metrics
 
-#import warnings
-#warnings.filterwarnings("ignore", message=".*force_all_finite.*")
-
 from annotator import Almanac as AnnotatorAlmanac
 from annotator import PreclinicalMatchmaking as AnnotatorPreclinicalMatchmaking
 from datasources import Almanac as DatasourceAlmanac

--- a/moalmanac/matchmaker.py
+++ b/moalmanac/matchmaker.py
@@ -545,18 +545,15 @@ class SNFTypesCGCwithEvidence(Models):
         boolean_dataframe_1 = AlmanacFeatures.create_boolean_table(inputs, samples, almanac_subset)
 
         data = [
-            boolean_dataframe_variants.loc[samples, :],#.fillna(0),
-            boolean_dataframe_copy_numbers.loc[samples, :],#.fillna(0),
-            boolean_dataframe_fusions.loc[samples, :],#.fillna(0),
-            boolean_dataframe_1.loc[samples, :]#.fillna(0),
+            boolean_dataframe_variants.loc[samples, :].fillna(0),
+            boolean_dataframe_copy_numbers.loc[samples, :].fillna(0),
+            boolean_dataframe_fusions.loc[samples, :].fillna(0),
+            boolean_dataframe_1.loc[samples, :].fillna(0)
         ]
 
         np.random.seed(seed)
-        print('Running make affinity')
         affinity_networks = SNF.make_affinity(data, metric='jaccard', normalize=False, K=20, mu=0.5)
-        print('Fusing network')
         fused_network = SNF.snf(affinity_networks, K=20)
-        print('Network fused')
         fused_dataframe = pd.DataFrame(fused_network, index=samples, columns=samples)
         distance_dataframe = pd.DataFrame(1, index=samples, columns=samples).subtract(fused_dataframe)
         stacked_dataframe = cls.stack_distances(distance_dataframe, cls.label)

--- a/moalmanac/snf.py
+++ b/moalmanac/snf.py
@@ -1,6 +1,12 @@
 """
-This file is adapted from the snfpy project:
-https://github.com/rmarkello/snfpy/tree/master
+This file is adapted from the snfpy repository, https://github.com/rmarkello/snfpy/tree/master,
+which is a translation of the original Similarity Network Fusion (SNF) code, implemented in R
+and matlab: http://compbio.cs.toronto.edu/SNF/SNF/Software.html
+
+Original publication:
+Wang, B., Mezlini, A. M., Demir, F., Fiume, M., Tu, Z., Brudno, M., Haibe-Kains, B., &
+Goldenberg, A. (2014). Similarity network fusion for aggregating data types on a genomic scale.
+Nature Methods, 11(3), 333.
 
 Original license: GNU Lesser General Public License v3.0 (LGPL-3.0)
 See: https://www.gnu.org/licenses/lgpl-3.0.html

--- a/moalmanac/snf.py
+++ b/moalmanac/snf.py
@@ -1,0 +1,640 @@
+"""
+This file is adapted from the snfpy project:
+https://github.com/rmarkello/snfpy/tree/master
+
+Original license: GNU Lesser General Public License v3.0 (LGPL-3.0)
+See: https://www.gnu.org/licenses/lgpl-3.0.html
+
+Modifications were made by Van Allen lab, Dana-Farber Cancer Institute in 2025 for compatibility
+with Python 3.12+ and updated versions of NumPy and scikit-learn.
+"""
+
+import numpy as np
+from scipy.spatial.distance import cdist
+from scipy import sparse, stats
+from sklearn.utils.validation import check_array, check_symmetric, check_consistent_length
+
+class SNF:
+    @classmethod
+    def _flatten(cls, messy):
+        """
+        Flattens a messy list of mixed iterables / not-iterables
+
+        Parameters
+        ----------
+        messy : list of ???
+            Combined list of iterables / non-iterables
+
+        Yields
+        ------
+        data : ???
+            Entries from `messy`
+
+        Notes
+        -----
+        Thanks to https://stackoverflow.com/a/2158532 :chef-kissing-fingers-emoji:
+        """
+
+        for m in messy:
+            if isinstance(m, (list, tuple)):
+                yield from cls._flatten(m)
+            else:
+                yield m
+
+    @classmethod
+    def _check_data_metric(cls, data, metric):
+        """
+        Confirms inputs to `make_affinity()` are appropriate
+
+        Parameters
+        ----------
+        data : (F,) list of (M, N) array_like
+            Input data arrays. All arrays should have same first dimension
+        metric : str or (F,) list of str
+            Input distance metrics. If provided as a list, should be the same
+            length as `data`
+
+        Yields
+        ------
+        data, metric : numpy.ndarray, str
+            Tuples of an input data array and the corresponding distance metric
+        """
+
+        # make sure all inputs are the same length
+        check_consistent_length(*list(cls._flatten(data)))
+
+        # check provided metric -- if not a list, make it so
+        if not isinstance(metric, (list, tuple)):
+            metric = [metric] * len(data)
+
+        # expand provided data arrays and metric so that it's 1:1
+        for d, m in zip(data, metric):
+            # if it's an iterable, recurse down
+            if isinstance(d, (list, tuple)):
+                yield from cls._check_data_metric(d, m)
+            else:
+                yield check_array(d, force_all_finite=False), m
+
+    @classmethod
+    def make_affinity(cls, *data, metric='sqeuclidean', K=20, mu=0.5, normalize=True):
+        r"""
+        Constructs affinity (i.e., similarity) matrix from `data`
+
+        Performs columnwise normalization on `data`, computes distance matrix based
+        on provided `metric`, and then constructs affinity matrix. Uses a scaled
+        exponential similarity kernel to determine the weight of each edge based on
+        the distance matrix. Optional hyperparameters `K` and `mu` determine the
+        extent of the scaling (see `Notes`).
+
+        Parameters
+        ----------
+        *data : (N, M) array_like
+            Raw data array, where `N` is samples and `M` is features. If multiple
+            arrays are provided then affinity matrices will be generated for each.
+        metric : str or list-of-str, optional
+            Distance metric to compute. Must be one of available metrics in
+            :py:func`scipy.spatial.distance.pdist`. If multiple arrays a provided
+            an equal number of metrics may be supplied. Default: 'sqeuclidean'
+        K : (0, N) int, optional
+            Number of neighbors to consider when creating affinity matrix. See
+            `Notes` of :py:func`snf.compute.affinity_matrix` for more details.
+            Default: 20
+        mu : (0, 1) float, optional
+            Normalization factor to scale similarity kernel when constructing
+            affinity matrix. See `Notes` of :py:func`snf.compute.affinity_matrix`
+            for more details. Default: 0.5
+        normalize : bool, optional
+            Whether to normalize (i.e., zscore) `arr` before constructing the
+            affinity matrix. Each feature (i.e., column) is normalized separately.
+            Default: True
+
+        Returns
+        -------
+        affinity : (N, N) numpy.ndarray or list of numpy.ndarray
+            Affinity matrix (or matrices, if multiple inputs provided)
+
+        Notes
+        -----
+        The scaled exponential similarity kernel, based on the probability density
+        function of the normal distribution, takes the form:
+
+        .. math::
+
+           \mathbf{W}(i, j) = \frac{1}{\sqrt{2\pi\sigma^2}}
+                              \ exp^{-\frac{\rho^2(x_{i},x_{j})}{2\sigma^2}}
+
+        where :math:`\rho(x_{i},x_{j})` is the Euclidean distance (or other
+        distance metric, as appropriate) between patients :math:`x_{i}` and
+        :math:`x_{j}`. The value for :math:`\\sigma` is calculated as:
+
+        .. math::
+
+           \sigma = \mu\ \frac{\overline{\rho}(x_{i},N_{i}) +
+                               \overline{\rho}(x_{j},N_{j}) +
+                               \rho(x_{i},x_{j})}
+                              {3}
+
+        where :math:`\overline{\rho}(x_{i},N_{i})` represents the average value
+        of distances between :math:`x_{i}` and its neighbors :math:`N_{1..K}`,
+        and :math:`\mu\in(0, 1)\subset\mathbb{R}`.
+
+        Examples
+        --------
+        >>> from snf import datasets
+        >>> simdata = datasets.load_simdata()
+
+        >>> from snf import compute
+        >>> aff = compute.make_affinity(simdata.data[0], K=20, mu=0.5)
+        >>> aff.shape
+        (200, 200)
+        """
+
+        affinity = []
+        for inp, met in cls._check_data_metric(data, metric):
+            # normalize data, taking into account potentially missing data
+            if normalize:
+                mask = np.isnan(inp).all(axis=1)
+                zarr = np.zeros_like(inp)
+                zarr[mask] = np.nan
+                zarr[~mask] = np.nan_to_num(stats.zscore(inp[~mask], ddof=1))
+            else:
+                zarr = inp
+
+            # construct distance matrix using `metric` and make affinity matrix
+            distance = cdist(zarr, zarr, metric=met)
+            affinity += [cls.affinity_matrix(distance, K=K, mu=mu)]
+
+        # match input type (if only one array provided, return array not list)
+        if len(data) == 1 and not isinstance(data[0], list):
+            affinity = affinity[0]
+
+        return affinity
+
+    @classmethod
+    def affinity_matrix(cls, dist, *, K=20, mu=0.5):
+        r"""
+        Calculates affinity matrix given distance matrix `dist`
+
+        Uses a scaled exponential similarity kernel to determine the weight of each
+        edge based on `dist`. Optional hyperparameters `K` and `mu` determine the
+        extent of the scaling (see `Notes`).
+
+        You'd probably be best to use :py:func`snf.compute.make_affinity` instead
+        of this, as that command also handles normalizing the inputs and creating
+        the distance matrix.
+
+        Parameters
+        ----------
+        dist : (N, N) array_like
+            Distance matrix
+        K : (0, N) int, optional
+            Number of neighbors to consider. Default: 20
+        mu : (0, 1) float, optional
+            Normalization factor to scale similarity kernel. Default: 0.5
+
+        Returns
+        -------
+        W : (N, N) np.ndarray
+            Affinity matrix
+
+        Notes
+        -----
+        The scaled exponential similarity kernel, based on the probability density
+        function of the normal distribution, takes the form:
+
+        .. math::
+
+           \mathbf{W}(i, j) = \frac{1}{\sqrt{2\pi\sigma^2}}
+                              \ exp^{-\frac{\rho^2(x_{i},x_{j})}{2\sigma^2}}
+
+        where :math:`\rho(x_{i},x_{j})` is the Euclidean distance (or other
+        distance metric, as appropriate) between patients :math:`x_{i}` and
+        :math:`x_{j}`. The value for :math:`\\sigma` is calculated as:
+
+        .. math::
+
+           \sigma = \mu\ \frac{\overline{\rho}(x_{i},N_{i}) +
+                               \overline{\rho}(x_{j},N_{j}) +
+                               \rho(x_{i},x_{j})}
+                              {3}
+
+        where :math:`\overline{\rho}(x_{i},N_{i})` represents the average value
+        of distances between :math:`x_{i}` and its neighbors :math:`N_{1..K}`,
+        and :math:`\mu\in(0, 1)\subset\mathbb{R}`.
+
+        Examples
+        --------
+        >>> from snf import datasets
+        >>> simdata = datasets.load_simdata()
+
+        We need to construct a distance matrix before we can create a similarity
+        matrix using :py:func:`snf.compute.affinity_matrix`:
+
+        >>> from scipy.spatial.distance import cdist
+        >>> dist = cdist(simdata.data[0], simdata.data[0])
+
+        >>> from snf import compute
+        >>> aff = compute.affinity_matrix(dist)
+        >>> aff.shape
+        (200, 200)
+        """
+
+        # check inputs
+        dist = check_array(dist, force_all_finite=False)
+        dist = check_symmetric(dist, raise_warning=False)
+
+        # get mask for potential NaN values and set diagonals zero
+        mask = np.isnan(dist)
+        dist[np.diag_indices_from(dist)] = 0
+
+        # sort array and get average distance to K nearest neighbors
+        T = np.sort(dist, axis=1)
+        TT = np.vstack(T[:, 1:K + 1].mean(axis=1) + np.spacing(1))
+
+        # compute sigma (see equation in Notes)
+        sigma = (TT + TT.T + dist) / 3
+        msigma = np.ma.array(sigma, mask=mask)  # mask for NaN
+        sigma = sigma * np.ma.greater(msigma, np.spacing(1)).data + np.spacing(1)
+
+        # get probability density function with scale = mu*sigma and symmetrize
+        scale = (mu * np.nan_to_num(sigma)) + mask
+        W = stats.norm.pdf(np.nan_to_num(dist), loc=0, scale=scale)
+        W[mask] = np.nan
+        W = check_symmetric(W, raise_warning=False)
+
+        return W
+
+    @classmethod
+    def _find_dominate_set(cls, W, K=20):
+        """
+        Retains `K` strongest edges for each sample in `W`
+
+        Parameters
+        ----------
+        W : (N, N) array_like
+            Input data
+        K : (0, N) int, optional
+            Number of neighbors to retain. Default: 20
+
+        Returns
+        -------
+        Wk : (N, N) np.ndarray
+            Thresholded version of `W`
+        """
+
+        # let's not modify W in place
+        Wk = W.copy()
+
+        # determine percentile cutoff that will keep only `K` edges for each sample
+        # remove everything below this cutoff
+        cutoff = 100 - (100 * (K / len(W)))
+        Wk[Wk < np.percentile(Wk, cutoff, axis=1, keepdims=True)] = 0
+
+        # normalize by strength of remaining edges
+        Wk = Wk / np.nansum(Wk, axis=1, keepdims=True)
+
+        return Wk
+
+    @classmethod
+    def _B0_normalized(cls, W, alpha=1.0):
+        """
+        Adds `alpha` to the diagonal of `W`
+
+        Parameters
+        ----------
+        W : (N, N) array_like
+            Similarity array from SNF
+        alpha : (0, 1) float, optional
+            Factor to add to diagonal of `W` to increase subject self-affinity.
+            Default: 1.0
+
+        Returns
+        -------
+        W : (N, N) np.ndarray
+            Normalized similiarity array
+        """
+
+        # add `alpha` to the diagonal and symmetrize `W`
+        W = W + (alpha * np.eye(len(W)))
+        W = check_symmetric(W, raise_warning=False)
+
+        return W
+
+    @classmethod
+    def snf(cls, *aff, K=20, t=20, alpha=1.0):
+        r"""
+        Performs Similarity Network Fusion on `aff` matrices
+
+        Parameters
+        ----------
+        *aff : (N, N) array_like
+            Input similarity arrays; all arrays should be square and of equal size.
+        K : (0, N) int, optional
+            Hyperparameter normalization factor for scaling. Default: 20
+        t : int, optional
+            Number of iterations to perform information swapping. Default: 20
+        alpha : (0, 1) float, optional
+            Hyperparameter normalization factor for scaling. Default: 1.0
+
+        Returns
+        -------
+        W: (N, N) np.ndarray
+            Fused similarity network of input arrays
+
+        Notes
+        -----
+        In order to fuse the supplied :math:`m` arrays, each must be normalized. A
+        traditional normalization on an affinity matrix would suffer from numerical
+        instabilities due to the self-similarity along the diagonal; thus, a
+        modified normalization is used:
+
+        .. math::
+
+           \mathbf{P}(i,j) =
+             \left\{\begin{array}{rr}
+               \frac{\mathbf{W}_(i,j)}
+                     {2 \sum_{k\neq i}^{} \mathbf{W}_(i,k)} ,& j \neq i \\
+                                                           1/2 ,& j = i
+             \end{array}\right.
+
+        Under the assumption that local similarities are more important than
+        distant ones, a more sparse weight matrix is calculated based on a KNN
+        framework:
+
+        .. math::
+
+           \mathbf{S}(i,j) =
+             \left\{\begin{array}{rr}
+               \frac{\mathbf{W}_(i,j)}
+                     {\sum_{k\in N_{i}}^{}\mathbf{W}_(i,k)} ,& j \in N_{i} \\
+                                                             0 ,& \text{otherwise}
+             \end{array}\right.
+
+        The two weight matrices :math:`\mathbf{P}` and :math:`\mathbf{S}` thus
+        provide information about a given patient's similarity to all other
+        patients and the `K` most similar patients, respectively.
+
+        These :math:`m` matrices are then iteratively fused. At each iteration, the
+        matrices are made more similar to each other via:
+
+        .. math::
+
+           \mathbf{P}^{(v)} = \mathbf{S}^{(v)}
+                              \times
+                              \frac{\sum_{k\neq v}^{}\mathbf{P}^{(k)}}{m-1}
+                              \times
+                              (\mathbf{S}^{(v)})^{T},
+                              v = 1, 2, ..., m
+
+        After each iteration, the resultant matrices are normalized via the
+        equation above. Fusion stops after `t` iterations, or when the matrices
+        :math:`\mathbf{P}^{(v)}, v = 1, 2, ..., m` converge.
+
+        The output fused matrix is full rank and can be subjected to clustering and
+        classification.
+        """
+
+        aff = cls._check_SNF_inputs(aff)
+        Wk = [0] * len(aff)
+        Wsum = np.zeros(aff[0].shape)
+
+        # get number of modalities informing each subject x subject affinity
+        n_aff = len(aff) - np.sum([np.isnan(a) for a in aff], axis=0)
+
+        for n, mat in enumerate(aff):
+            # normalize affinity matrix based on strength of edges
+            mat = mat / np.nansum(mat, axis=1, keepdims=True)
+            aff[n] = check_symmetric(mat, raise_warning=False)
+            # apply KNN threshold to normalized affinity matrix
+            Wk[n] = cls._find_dominate_set(aff[n], int(K))
+
+        # take sum of all normalized (not thresholded) affinity matrices
+        Wsum = np.nansum(aff, axis=0)
+
+        for iteration in range(t):
+            for n, mat in enumerate(aff):
+                # temporarily convert nans to 0 to avoid propagation errors
+                nzW = np.nan_to_num(Wk[n])
+                aw = np.nan_to_num(mat)
+                # propagate `Wsum` through masked affinity matrix (`nzW`)
+                aff0 = nzW @ (Wsum - aw) @ nzW.T / (n_aff - 1)  # TODO: / by 0
+                # ensure diagonal retains highest similarity
+                aff[n] = cls._B0_normalized(aff0, alpha=alpha)
+
+            # compute updated sum of normalized affinity matrices
+            Wsum = np.nansum(aff, axis=0)
+
+        # all entries of `aff` should be identical after the fusion procedure
+        # dividing by len(aff) is hypothetically equivalent to selecting one
+        # however, if fusion didn't converge then this is just average of `aff`
+        W = Wsum / len(aff)
+
+        # normalize fused matrix and update diagonal similarity
+        W = W / np.nansum(W, axis=1, keepdims=True)  # TODO: / by NaN
+        W = (W + W.T + np.eye(len(W))) / 2
+
+        return W
+
+    @classmethod
+    def _check_SNF_inputs(cls, aff):
+        """
+        Confirms inputs to SNF are appropriate
+
+        Parameters
+        ----------
+        aff : `m`-list of (N x N) array_like
+            Input similarity arrays. All arrays should be square and of equal size.
+        """
+
+        prep = []
+        for a in cls._flatten(aff):
+            ac = check_array(a, force_all_finite=True, copy=True)
+            prep.append(check_symmetric(ac, raise_warning=False))
+        check_consistent_length(*prep)
+
+        # TODO: actually do this check for missing data
+        nanaff = len(prep) - np.sum([np.isnan(a) for a in prep], axis=0)
+        if np.any(nanaff == 0):
+            pass
+
+        return prep
+
+    @classmethod
+    def _label_prop(cls, W, Y, *, t=1000):
+        """
+        Label propagation of labels in `Y` via similarity of `W`
+
+        Parameters
+        ----------
+        W : (N, N) array_like
+            Similarity array generated by `SNF`
+        Y : (N, G) array_like
+            Dummy-coded array grouping N subjects in G groups. Some subjects should
+            have no group indicated
+        t : int, optional
+            Number of iterations to perform label propagation. Default: 1000
+
+        Returns
+        -------
+        Y : (N, G) array_like
+            Psuedo-dummy-coded array grouping N subjects into G groups. Subjects
+            with no group indicated now have continuous weights indicating
+            likelihood of group membership
+        """
+
+        W_norm, Y_orig = cls._dnorm(W, 'ave'), Y.copy()
+        train_index = Y.sum(axis=1) == 1
+
+        for iteration in range(t):
+            Y = W_norm @ Y
+            # retain training labels every iteration
+            Y[train_index, :] = Y_orig[train_index, :]
+
+        return Y
+
+    @classmethod
+    def _dnorm(cls, W, norm='ave'):
+        """
+        Normalizes a symmetric kernel `W`
+
+        Parameters
+        ----------
+        W : (N, N) array_like
+            Similarity array generated by `SNF`
+        norm : str, optional
+            Type of normalization to perform. Must be one of ['ave', 'gph'].
+            Default: 'ave'
+
+        Returns
+        -------
+        W_norm : (N, N) array_like
+            Normalized `W`
+        """
+
+        if norm not in ['ave', 'gph']:
+            raise ValueError('Provided `norm` {} not in [\'ave\', \'gph\'].'
+                             .format(norm))
+
+        D = W.sum(axis=1) + np.spacing(1)
+
+        if norm == 'ave':
+            W_norm = sparse.diags(1. / D) @ W
+        else:
+            D = sparse.diags(1. / np.sqrt(D))
+            W_norm = D @ (W @ D)
+
+        return W_norm
+
+    @classmethod
+    def group_predict(cls, train, test, labels, *, K=20, mu=0.4, t=20):
+        """
+        Propagates `labels` from `train` data to `test` data via SNF
+
+        Parameters
+        ----------
+        train : `m`-list of (S1, F) array_like
+            Input subject x feature training data. Subjects in these data sets
+            should have been previously labelled (see: `labels`).
+        test : `m`-list of (S2, F) array_like
+            Input subject x feature testing data. These should be similar to the
+            data in `train` (though the first dimension can differ). Labels will be
+            propagated to these subjects.
+        labels : (S1,) array_like
+            Cluster labels for `S1` subjects in `train` data sets. These could have
+            been obtained from some ground-truth labelling or via a previous
+            iteration of SNF with only the `train` data (e.g., the output of
+            :py:func:`sklearn.cluster.spectral_clustering` would be appropriate).
+        K : (0, N) int, optional
+            Hyperparameter normalization factor for scaling. See `Notes` of
+            `snf.affinity_matrix` for more details. Default: 20
+        mu : (0, 1) float, optional
+            Hyperparameter normalization factor for scaling. See `Notes` of
+            `snf.affinity_matrix` for more details. Default: 0.5
+        t : int, optional
+            Number of iterations to perform information swapping during SNF.
+            Default: 20
+
+        Returns
+        -------
+        predicted_labels : (S2,) np.ndarray
+            Cluster labels for subjects in `test` assigning to groups in `labels`
+        """
+
+        # check inputs are legit
+        try:
+            check_consistent_length(train, test)
+        except ValueError:
+            raise ValueError('Training and testing set must have same number of '
+                             'data types.')
+        if not all([len(labels) == len(t) for t in train]):
+            raise ValueError('Training data must have the same number of subjects '
+                             'as provided labels.')
+
+        # generate affinity matrices for stacked train/test data sets
+        affinities = []
+        for (tr, te) in zip(train, test):
+            try:
+                check_consistent_length(tr.T, te.T)
+            except ValueError:
+                raise ValueError('Train and test data must have same number of '
+                                 'features for each data type. Make sure to '
+                                 'supply data types in the same order.')
+            affinities += [cls.make_affinity(np.row_stack([tr, te]), K=K, mu=mu)]
+
+        # fuse with SNF
+        fused_aff = cls.snf(*affinities, K=K, t=t)
+
+        # get unique groups in training data and generate array to hold all labels
+        groups = np.unique(labels)
+        all_labels = np.zeros((len(fused_aff), groups.size))
+        # reassign training labels to all_labels array
+        for i in range(groups.size):
+            all_labels[np.where(labels == groups[i])[0], i] = 1
+
+        # propagate labels from train data to test data using SNF fused array
+        propagated_labels = cls._label_prop(fused_aff, all_labels, t=1000)
+        predicted_labels = groups[propagated_labels[len(train[0]):].argmax(axis=1)]
+
+        return predicted_labels
+
+    @classmethod
+    def get_n_clusters(cls, arr, n_clusters=range(2, 6)):
+        """
+        Finds optimal number of clusters in `arr` via eigengap method
+
+        Parameters
+        ----------
+        arr : (N, N) array_like
+            Input array (e.g., the output of :py:func`snf.compute.snf`)
+        n_clusters : array_like
+            Numbers of clusters to choose between
+
+        Returns
+        -------
+        opt_cluster : int
+            Optimal number of clusters
+        second_opt_cluster : int
+            Second best number of clusters
+        """
+
+        # confirm inputs are appropriate
+        n_clusters = check_array(n_clusters, ensure_2d=False)
+        n_clusters = n_clusters[n_clusters > 1]
+
+        # don't overwrite provided array!
+        graph = arr.copy()
+
+        graph = (graph + graph.T) / 2
+        graph[np.diag_indices_from(graph)] = 0
+        degree = graph.sum(axis=1)
+        degree[np.isclose(degree, 0)] += np.spacing(1)
+        di = np.diag(1 / np.sqrt(degree))
+        laplacian = di @ (np.diag(degree) - graph) @ di
+
+        # perform eigendecomposition and find eigengap
+        eigs = np.sort(np.linalg.eig(laplacian)[0])
+        eigengap = np.abs(np.diff(eigs))
+        eigengap = eigengap * (1 - eigs[:-1]) / (1 - eigs[1:])
+        n = eigengap[n_clusters - 1].argsort()[::-1]
+
+        return n_clusters[n[:2]]

--- a/moalmanac/snf.py
+++ b/moalmanac/snf.py
@@ -79,7 +79,7 @@ class SNF:
             if isinstance(d, (list, tuple)):
                 yield from cls._check_data_metric(d, m)
             else:
-                yield check_array(d, force_all_finite=False), m
+                yield check_array(d, ensure_all_finite=False), m
 
     @classmethod
     def make_affinity(cls, *data, metric='sqeuclidean', K=20, mu=0.5, normalize=True):
@@ -220,7 +220,7 @@ class SNF:
         """
 
         # check inputs
-        dist = check_array(dist, force_all_finite=False)
+        dist = check_array(dist, ensure_all_finite=False)
         dist = check_symmetric(dist, raise_warning=False)
 
         # get mask for potential NaN values and set diagonals zero
@@ -437,7 +437,7 @@ class SNF:
 
         prep = []
         for a in cls._flatten(aff):
-            ac = check_array(a, force_all_finite=True, copy=True)
+            ac = check_array(a, ensure_all_finite=True, copy=True)
             prep.append(check_symmetric(ac, raise_warning=False))
         check_consistent_length(*prep)
 

--- a/moalmanac/snf.py
+++ b/moalmanac/snf.py
@@ -143,16 +143,6 @@ class SNF:
         where :math:`\overline{\rho}(x_{i},N_{i})` represents the average value
         of distances between :math:`x_{i}` and its neighbors :math:`N_{1..K}`,
         and :math:`\mu\in(0, 1)\subset\mathbb{R}`.
-
-        Examples
-        --------
-        >>> from snf import datasets
-        >>> simdata = datasets.load_simdata()
-
-        >>> from snf import compute
-        >>> aff = compute.make_affinity(simdata.data[0], K=20, mu=0.5)
-        >>> aff.shape
-        (200, 200)
         """
 
         affinity = []
@@ -227,22 +217,6 @@ class SNF:
         where :math:`\overline{\rho}(x_{i},N_{i})` represents the average value
         of distances between :math:`x_{i}` and its neighbors :math:`N_{1..K}`,
         and :math:`\mu\in(0, 1)\subset\mathbb{R}`.
-
-        Examples
-        --------
-        >>> from snf import datasets
-        >>> simdata = datasets.load_simdata()
-
-        We need to construct a distance matrix before we can create a similarity
-        matrix using :py:func:`snf.compute.affinity_matrix`:
-
-        >>> from scipy.spatial.distance import cdist
-        >>> dist = cdist(simdata.data[0], simdata.data[0])
-
-        >>> from snf import compute
-        >>> aff = compute.affinity_matrix(dist)
-        >>> aff.shape
-        (200, 200)
         """
 
         # check inputs

--- a/moalmanac/snf.py
+++ b/moalmanac/snf.py
@@ -397,7 +397,16 @@ class SNF:
                 nzW = np.nan_to_num(Wk[n])
                 aw = np.nan_to_num(mat)
                 # propagate `Wsum` through masked affinity matrix (`nzW`)
-                aff0 = nzW @ (Wsum - aw) @ nzW.T / (n_aff - 1)  # TODO: / by 0
+
+                # Modified by Van Allen lab
+                ## safe denominator
+                denominator = np.maximum(n_aff -1, 1)
+
+                ## Compute aff0 with safe broadcasting
+                with np.errstate(divide='ignore', invalid='ignore', over='ignore'):
+                    aff0 = nzW @ (Wsum - aw) @ nzW.T
+                    aff0 = np.divide(aff0, denominator, out=np.zeros_like(aff0), where=denominator!=0)
+
                 # ensure diagonal retains highest similarity
                 aff[n] = cls._B0_normalized(aff0, alpha=alpha)
 

--- a/moalmanac/test/annotator_tests.py
+++ b/moalmanac/test/annotator_tests.py
@@ -263,25 +263,25 @@ class UnitTestValidation(unittest.TestCase):
         self.assertEqual([0.4103, '', 0.9715, 0.0], result['validation_detection_power'].tolist())
 
     def test_calculate_beta_binomial(self):
-        self.assertEqual(0.7006851149078945, stats.betabinom.sf(k=3, n=5, a=2.3, b=0.63))
+        self.assertAlmostEqual(0.7006851149078945, stats.betabinom.sf(k=3, n=5, a=2.3, b=0.63), places=10)
         self.assertEqual(0.7007, round(stats.betabinom.sf(k=3, n=5, a=2.3, b=0.63), 4))
         series_n = pd.Series([10, 50, 100])
         series_a = pd.Series([5, 25, 50])
         series_b = pd.Series([15, 40, 100])
         solutions = list(stats.betabinom.sf(k=3, n=series_n, a=series_a, b=series_b, loc=0))
-        self.assertEqual(0.25543941316055174, solutions[0])
-        self.assertEqual(0.9999749071547652, solutions[1])
-        self.assertEqual(0.9999999996130999, solutions[2])
+        self.assertAlmostEqual(0.25543941316055174, solutions[0], places=10)
+        self.assertAlmostEqual(0.9999749071547652, solutions[1], places=10)
+        self.assertAlmostEqual(0.9999999996130999, solutions[2], places=10)
 
     def test_calculate_validation_detection_power(self):
         tumor_f = pd.Series([0, 0.33, 0.5, 1])
         coverage = pd.Series([5, 100, 50, 66])
         validation_coverage = pd.Series([12, 70, 40, 20])
         result = OverlapValidation.calculate_validation_detection_power(tumor_f, coverage, validation_coverage)
-        self.assertEqual(0.16176470588235325, result[0])
-        self.assertEqual(0.999998846495356, result[1])
-        self.assertEqual(0.9999945730050155, result[2])
-        self.assertEqual(0.9999999999999977, result[3])
+        self.assertAlmostEqual(0.16176470588235325, result[0], places=10)
+        self.assertAlmostEqual(0.999998846495356, result[1], places=10)
+        self.assertAlmostEqual(0.9999945730050155, result[2], places=10)
+        self.assertAlmostEqual(0.9999999999999977, result[3], places=10)
 
     def test_drop_validation_columns(self):
         columns = ['A', 'B', OverlapValidation.validation_tumor_f, OverlapValidation.validation_coverage, 'C']

--- a/moalmanac/test/investigator_tests.py
+++ b/moalmanac/test/investigator_tests.py
@@ -46,7 +46,7 @@ class UnitTestSensitivityDictionary(unittest.TestCase):
         series2 = pd.Series([1, 2, 3, 4, 5, 6], name='value')
         series3 = pd.Series([], dtype=float, name='value')
         statistic, pvalue = SensitivityDictionary.calculate_mann_whitney_u(series1, series2)
-        self.assertEqual(pvalue, 0.25642920468772246)
+        self.assertAlmostEqual(pvalue, 0.25642920468772246, places=10)
         self.assertEqual(statistic, 10.5)
         statistic, pvalue = SensitivityDictionary.calculate_mann_whitney_u(series1, series3)
         self.assertTrue(math.isnan(pvalue))
@@ -82,8 +82,8 @@ class UnitTestSensitivityDictionary(unittest.TestCase):
         expected_trametinib = '2.344e-09'
         config = Ini.read('config.ini', extended_interpolation=False, convert_to_dictionary=False)
         result = SensitivityDictionary.create(dbs, actionable, config)
-        self.assertEqual(result[0]['Dabrafenib']['BRAF']['comparison']['pvalue_mww'], expected_dabrafenib)
-        self.assertEqual(result[0]['Trametinib']['BRAF']['comparison']['pvalue_mww'], expected_trametinib)
+        self.assertAlmostEqual(result[0]['Dabrafenib']['BRAF']['comparison']['pvalue_mww'], expected_dabrafenib, places=10)
+        self.assertAlmostEqual(result[0]['Trametinib']['BRAF']['comparison']['pvalue_mww'], expected_trametinib, places=10)
 
     def test_create_drug_dict(self):
         all_samples = ['A', 'B', 'C', 'D']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ flask==3.0.2
 Frozen-Flask==1.0.2
 ipykernel==6.29.4
 jupyter==1.0.0
-matplotlib==3.8.3
-numpy==1.26.4
+matplotlib==3.10.0
+numpy==2.3.0
 pandas==2.2.2
-requests==2.31.0
-scikit-learn==1.4.2
-scipy==1.13.0
+requests==2.32.4
+scikit-learn==1.7.0
+scipy==1.16.0
 snfpy==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ pandas==2.2.2
 requests==2.32.4
 scikit-learn==1.7.0
 scipy==1.16.0
-snfpy==0.2.2


### PR DESCRIPTION
This Pull Request involved removing warnings associated with running moalmanac on Python 3.13. Resolving these warnings were detailed in [this Issue](https://github.com/vanallenlab/moalmanac/issues/41). We will leave the repository on Python 3.12 for the time being. The version of the interpreter was updated to 0.8.2.

In short, two warnings were produced from [`snfpy`](https://github.com/rmarkello/snfpy/tree/master), as it still primarily supports Python 3.5 & Python 3.6. We integrated the relevant code from their repository since the repo has not been updated since March 2020, with appropriate attribution. The two warnings were:

```
/opt/miniconda3/envs/moalmanac-3.12/lib/python3.12/site-packages/sklearn/utils/deprecation.py:132: FutureWarning: 'force_all_finite' was renamed to 'ensure_all_finite' in 1.6 and will be removed in 1.8.
```

```
  warnings.warn(
/opt/miniconda3/envs/moalmanac-3.12/lib/python3.12/site-packages/snf/compute.py:415: RuntimeWarning: divide by zero encountered in matmul
  aff0 = nzW @ (Wsum - aw) @ nzW.T / (n_aff - 1)  # TODO: / by 0
/opt/miniconda3/envs/moalmanac-3.12/lib/python3.12/site-packages/snf/compute.py:415: RuntimeWarning: overflow encountered in matmul
  aff0 = nzW @ (Wsum - aw) @ nzW.T / (n_aff - 1)  # TODO: / by 0
/opt/miniconda3/envs/moalmanac-3.12/lib/python3.12/site-packages/snf/compute.py:415: RuntimeWarning: invalid value encountered in matmul
  aff0 = nzW @ (Wsum - aw) @ nzW.T / (n_aff - 1)  # TODO: / by 0
```

Additions:
- The [compute](https://github.com/rmarkello/snfpy/blob/master/snf/compute.py) module from [snfpy](https://github.com/rmarkello/snfpy/tree/master/snf) was moved to this repository under moalmanac/snf.py, with attribution via a comment at the top of the file, and the addition of a sub LICENSE for this code chunk and a NOTICE in the repository's root directory. We also appended a message at the bottom of our GNU GPL 2.0 LICENSE. We revised this file to place all functions inside of a class, to match the code style of other files in this repo.

Revisions:
- Unit tests involving precise comparisons of float values were updated to use `assertAlmostEqual` to 10 places instead of `assertEqual`. 
- Several dependencies were updated:
    - matplotlib: 3.8.3 > 3.10.0
    - numpy: 1.26.4 > 2.3.0
    - requests: 2.31.0 > 2.32.4
    - scikit-learn: 1.4.2 > 1.7.0
    - scipy: 1.13.0 > 1.16.0

Removed:
- `snfpy` was removed from `requirements.txt`. 

Pre-pull request check list,
- [x] Relevant documentation has been updated
- [x] All unit tests pass
- [x] All outputs pre- and post- changes match by md5 hash
- [x] All files changed have been reviewed
- [x] Docker pushed
