### PR TITLE
Resolve ini files to absolute paths

### DIFF
--- a/docs/description-of-inputs.md
+++ b/docs/description-of-inputs.md
@@ -57,7 +57,7 @@ This config file contains the following sections,
 `--dbs` expects a file path to the [annotation-databases.ini](../moalmanac/annotation-databases.ini) file.
 
 This config file contains a single section `databases` that lists the following:
-- `root` - path to `datasources/` directory
+- `root` - path to `datasources/` directory, relative to repository root.
 - `almanac_handle` - path within `root` that points to the `molecular-oncology-almanac.json` datasource file
 - `cancerhotspots_handle` - path within `root` that points to the Cancer Hotspots datasource file
 - `3dcancerhotspots_handle` - path within `root` that points to the Cancer Hotspots 3D datasource file
@@ -323,7 +323,7 @@ The required fields for this file can be changed from their default expectations
 - Performs genomic similarity to cancer cell lines
 
 This config file contains a single section `preclinical` that lists the following:
-- `root` - path to `datasources/preclinical/` directory
+- `root` - path to `datasources/preclinical/` directory, relative to repository root.
 - `almanac_gdsc_mappings` - path within `root` that points to the `formatted/almanac-gdsc-mappings.json` datasource file
 - `summary` - path within `root` that points to the `formatted/cell-lines.summary.txt` datasource file
 - `variants` - path within `root` that points to the `annotated/cell-lines.somatic-variants.annotated.txt` datasource file

--- a/moalmanac/annotation-databases.ini
+++ b/moalmanac/annotation-databases.ini
@@ -1,5 +1,6 @@
 [paths]
-; the root is relative to the moalmanac repository root directory
+; the root variable is relative to the moalmanac repository root directory
+; set resolve_paths=True with Ini.read to resolve to an absolute path
 root = datasources
 almanac_handle = ${root}/moalmanac/molecular-oncology-almanac.json
 cancerhotspots_handle = ${root}/cancerhotspots/hotspots_v2.txt

--- a/moalmanac/annotation-databases.ini
+++ b/moalmanac/annotation-databases.ini
@@ -1,5 +1,6 @@
 [paths]
-root = ../datasources
+; the root is relative to the moalmanac repository root directory
+root = datasources
 almanac_handle = ${root}/moalmanac/molecular-oncology-almanac.json
 cancerhotspots_handle = ${root}/cancerhotspots/hotspots_v2.txt
 3dcancerhotspots_handle = ${root}/cancerhotspots/hotspots3d.txt

--- a/moalmanac/annotation-databases.ini
+++ b/moalmanac/annotation-databases.ini
@@ -1,6 +1,6 @@
 [paths]
 ; the root variable is relative to the moalmanac repository root directory
-; set resolve_paths=True with Ini.read to resolve to an absolute path
+; use Ini.read(..., resolve_paths=True) to resolve [paths] entries to absolute paths
 root = datasources
 almanac_handle = ${root}/moalmanac/molecular-oncology-almanac.json
 cancerhotspots_handle = ${root}/cancerhotspots/hotspots_v2.txt

--- a/moalmanac/config.ini
+++ b/moalmanac/config.ini
@@ -13,7 +13,7 @@ include_preclinical_efficacy_in_actionability_report = on
 level = INFO
 
 [versions]
-interpreter = 0.8.5
+interpreter = 0.8.6
 database = v.2025-02-07
 
 [exac]

--- a/moalmanac/config.py
+++ b/moalmanac/config.py
@@ -1,19 +1,22 @@
 import configparser
+import pathlib
 
-default_colnames = 'colnames.ini'
+default_colnames = pathlib.Path(__file__).resolve().parent / "colnames.ini"
 
 
 def create_colnames_dict(config):
     dictionary = {}
     for section in config.sections():
         dictionary[section] = {}
-        for (key, value) in config.items(section):
+        for key, value in config.items(section):
             dictionary[section][key] = value
     return dictionary
 
 
 def create_colnames():
-    config = configparser.ConfigParser(interpolation=configparser.ExtendedInterpolation())
+    config = configparser.ConfigParser(
+        interpolation=configparser.ExtendedInterpolation()
+    )
     config.read(default_colnames)
     return create_colnames_dict(config)
 

--- a/moalmanac/moalmanac.py
+++ b/moalmanac/moalmanac.py
@@ -895,11 +895,11 @@ if __name__ == "__main__":
 
     config_ini = Ini.read(args.config, extended_interpolation=False, convert_to_dictionary=False)
 
-    db_paths = Ini.read(args.dbs, extended_interpolation=True, convert_to_dictionary=True)
+    db_paths = Ini.read(args.dbs, extended_interpolation=True, convert_to_dictionary=True, resolve_paths=True)
     db_paths = db_paths['paths']
 
     if args.preclinical_dbs:
-        preclinical_db_paths = Ini.read(args.preclinical_dbs, extended_interpolation=True, convert_to_dictionary=True)
+        preclinical_db_paths = Ini.read(args.preclinical_dbs, extended_interpolation=True, convert_to_dictionary=True, resolve_paths=True)
         preclinical_db_paths = preclinical_db_paths['paths']
     else:
         preclinical_db_paths = None

--- a/moalmanac/moalmanac.py
+++ b/moalmanac/moalmanac.py
@@ -3,6 +3,7 @@ import datetime
 import time
 import os
 import subprocess
+import sys
 
 import annotator
 import datasources
@@ -1128,17 +1129,35 @@ if __name__ == "__main__":
     }
 
     output_directory = args.output_directory if args.output_directory else os.getcwd()
+    try:
+        config_ini = Ini.read(
+            args.config, extended_interpolation=False, convert_to_dictionary=False
+        )
 
-    config_ini = Ini.read(args.config, extended_interpolation=False, convert_to_dictionary=False)
+        db_paths = Ini.read(
+            args.dbs,
+            extended_interpolation=True,
+            convert_to_dictionary=True,
+            resolve_paths=True,
+        )
+        db_paths = db_paths['paths']
 
-    db_paths = Ini.read(args.dbs, extended_interpolation=True, convert_to_dictionary=True, resolve_paths=True)
-    db_paths = db_paths['paths']
-
-    if args.preclinical_dbs:
-        preclinical_db_paths = Ini.read(args.preclinical_dbs, extended_interpolation=True, convert_to_dictionary=True, resolve_paths=True)
-        preclinical_db_paths = preclinical_db_paths['paths']
-    else:
-        preclinical_db_paths = None
+        if args.preclinical_dbs:
+            preclinical_db_paths = Ini.read(
+                args.preclinical_dbs,
+                extended_interpolation=True,
+                convert_to_dictionary=True,
+                resolve_paths=True,
+            )
+            preclinical_db_paths = preclinical_db_paths['paths']
+        else:
+            preclinical_db_paths = None
+    except FileNotFoundError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(2)
+    except RuntimeError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(2)
 
     main(
         patient=patient_dict,

--- a/moalmanac/preclinical-databases.ini
+++ b/moalmanac/preclinical-databases.ini
@@ -1,5 +1,5 @@
 [paths]
-root = ../datasources
+root = datasources
 almanac_gdsc_mappings = ${root}/preclinical/formatted/almanac-gdsc-mappings.json
 summary = ${root}/preclinical/formatted/cell-lines.summary.txt
 variants = ${root}/preclinical/annotated/cell-lines.somatic-variants.annotated.txt

--- a/moalmanac/preclinical-databases.ini
+++ b/moalmanac/preclinical-databases.ini
@@ -1,6 +1,6 @@
 [paths]
 ; the root variable is relative to the moalmanac repository root directory
-; set resolve_paths=True with Ini.read to resolve to an absolute path
+; use Ini.read(..., resolve_paths=True) to resolve [paths] entries to absolute paths
 root = datasources
 almanac_gdsc_mappings = ${root}/preclinical/formatted/almanac-gdsc-mappings.json
 summary = ${root}/preclinical/formatted/cell-lines.summary.txt

--- a/moalmanac/preclinical-databases.ini
+++ b/moalmanac/preclinical-databases.ini
@@ -1,4 +1,6 @@
 [paths]
+; the root variable is relative to the moalmanac repository root directory
+; set resolve_paths=True with Ini.read to resolve to an absolute path
 root = datasources
 almanac_gdsc_mappings = ${root}/preclinical/formatted/almanac-gdsc-mappings.json
 summary = ${root}/preclinical/formatted/cell-lines.summary.txt

--- a/moalmanac/reader.py
+++ b/moalmanac/reader.py
@@ -17,13 +17,23 @@ class Ini:
 
     @staticmethod
     def load(path, extended_interpolation=False):
+        path = pathlib.Path(path)
+
+        if not path.exists():
+            raise FileNotFoundError(f"INI file not found: {path}")
+        if not path.is_file():
+            raise FileNotFoundError(f"INI path is not a file: {path}")
+
         if extended_interpolation:
             config = configparser.ConfigParser(
                 interpolation=configparser.ExtendedInterpolation()
             )
         else:
             config = configparser.ConfigParser()
-        config.read(path)
+
+        read_okay = config.read(path)
+        if not read_okay:
+            raise RuntimeError(f"Failed to read Ini file: {path}")
         return config
 
     @classmethod

--- a/moalmanac/run_4x_for_output_regression_test.py
+++ b/moalmanac/run_4x_for_output_regression_test.py
@@ -7,8 +7,8 @@ from datetime import date
 
 from reader import Ini
 
-pre_or_post_code_changes = "pre"
-#pre_or_post_code_changes = "post"
+# pre_or_post_code_changes = "pre"
+pre_or_post_code_changes = "post"
 
 metadata_dictionary = {
     'patient_id': 'example',
@@ -18,7 +18,7 @@ metadata_dictionary = {
     'purity': 0.85,
     'ploidy': 4.02,
     'WGD': True,
-    'microsatellite_status': 'msih'
+    'microsatellite_status': 'msih',
 }
 
 input_dictionary_empty = {
@@ -31,7 +31,7 @@ input_dictionary_empty = {
     'germline_handle': '',
     'validation_handle': '',
     'mutational_signatures_path': '',
-    'disable_matchmaking': False
+    'disable_matchmaking': False,
 }
 
 input_dictionary = {
@@ -44,18 +44,30 @@ input_dictionary = {
     'germline_handle': '../example_data/example_patient.capture.germline.maf',
     'validation_handle': '../example_data/example_patient.rna.somatic.snvs.maf',
     'mutational_signatures_path': '../example_data/example_patient.capture.sbs_contributions.txt',
-    'disable_matchmaking': False
+    'disable_matchmaking': False,
 }
 
 config_ini_path = "config.ini"
-config_ini = Ini.read(config_ini_path, extended_interpolation=False, convert_to_dictionary=False)
+config_ini = Ini.read(
+    config_ini_path, extended_interpolation=False, convert_to_dictionary=False
+)
 
 dbs_ini_path = "annotation-databases.ini"
-db_paths = Ini.read(dbs_ini_path, extended_interpolation=True, convert_to_dictionary=True)
+db_paths = Ini.read(
+    dbs_ini_path,
+    extended_interpolation=True,
+    convert_to_dictionary=True,
+    resolve_paths=True,
+)
 db_paths = db_paths['paths']
 
 dbs_preclinical_ini_path = "preclinical-databases.ini"
-preclinical_db_paths = Ini.read(dbs_preclinical_ini_path, extended_interpolation=True, convert_to_dictionary=True)
+preclinical_db_paths = Ini.read(
+    dbs_preclinical_ini_path,
+    extended_interpolation=True,
+    convert_to_dictionary=True,
+    resolve_paths=True,
+)
 preclinical_db_paths = preclinical_db_paths['paths']
 
 
@@ -71,7 +83,9 @@ First execution, all example inputs with all settings within the function toggle
 for key, value in config_ini.items('function_toggle'):
     config_ini['function_toggle'][key] = 'on'
 
-output_directory = f"{today}-example-outputs-full-all-enabled-{pre_or_post_code_changes}"
+output_directory = (
+    f"{today}-example-outputs-full-all-enabled-{pre_or_post_code_changes}"
+)
 if output_directory != "":
     cmd = f"mkdir -p {output_directory}"
     execute_cmd(cmd)
@@ -86,12 +100,14 @@ moalmanac.main(
     output_folder=output_directory,
     config=config_ini,
     dbs=db_paths,
-    dbs_preclinical=preclinical_db_paths
+    dbs_preclinical=preclinical_db_paths,
 )
 
 end_time = time.time()
 
-time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round((end_time - start_time), 4)
+time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round(
+    (end_time - start_time), 4
+)
 print(time_statement)
 
 """
@@ -100,7 +116,9 @@ Second execution, all empty example inputs with all settings within the function
 for key, value in config_ini.items('function_toggle'):
     config_ini['function_toggle'][key] = 'on'
 
-output_directory = f"{today}-example-outputs-empty-all-enabled-{pre_or_post_code_changes}"
+output_directory = (
+    f"{today}-example-outputs-empty-all-enabled-{pre_or_post_code_changes}"
+)
 if output_directory != "":
     cmd = f"mkdir -p {output_directory}"
     execute_cmd(cmd)
@@ -114,11 +132,13 @@ moalmanac.main(
     output_folder=output_directory,
     config=config_ini,
     dbs=db_paths,
-    dbs_preclinical=preclinical_db_paths
+    dbs_preclinical=preclinical_db_paths,
 )
 end_time = time.time()
 
-time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round((end_time - start_time), 4)
+time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round(
+    (end_time - start_time), 4
+)
 print(time_statement)
 
 """
@@ -127,7 +147,9 @@ Third execution, all example inputs with all settings within the function toggle
 for key, value in config_ini.items('function_toggle'):
     config_ini['function_toggle'][key] = 'off'
 
-output_directory = f"{today}-example-outputs-full-all-disabled-{pre_or_post_code_changes}"
+output_directory = (
+    f"{today}-example-outputs-full-all-disabled-{pre_or_post_code_changes}"
+)
 if output_directory != "":
     cmd = f"mkdir -p {output_directory}"
     execute_cmd(cmd)
@@ -142,12 +164,14 @@ moalmanac.main(
     output_folder=output_directory,
     config=config_ini,
     dbs=db_paths,
-    dbs_preclinical=preclinical_db_paths
+    dbs_preclinical=preclinical_db_paths,
 )
 
 end_time = time.time()
 
-time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round((end_time - start_time), 4)
+time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round(
+    (end_time - start_time), 4
+)
 print(time_statement)
 
 """
@@ -156,7 +180,9 @@ Fourth execution, all empty example inputs with all settings within the function
 for key, value in config_ini.items('function_toggle'):
     config_ini['function_toggle'][key] = 'off'
 
-output_directory = f"{today}-example-outputs-empty-all-disabled-{pre_or_post_code_changes}"
+output_directory = (
+    f"{today}-example-outputs-empty-all-disabled-{pre_or_post_code_changes}"
+)
 if output_directory != "":
     cmd = f"mkdir -p {output_directory}"
     execute_cmd(cmd)
@@ -170,9 +196,11 @@ moalmanac.main(
     output_folder=output_directory,
     config=config_ini,
     dbs=db_paths,
-    dbs_preclinical=preclinical_db_paths
+    dbs_preclinical=preclinical_db_paths,
 )
 end_time = time.time()
 
-time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round((end_time - start_time), 4)
+time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round(
+    (end_time - start_time), 4
+)
 print(time_statement)

--- a/moalmanac/run_4x_for_output_regression_test.py
+++ b/moalmanac/run_4x_for_output_regression_test.py
@@ -7,8 +7,8 @@ from datetime import date
 
 from reader import Ini
 
-# pre_or_post_code_changes = "pre"
-pre_or_post_code_changes = "post"
+pre_or_post_code_changes = "pre"
+# pre_or_post_code_changes = "post"
 
 metadata_dictionary = {
     'patient_id': 'example',

--- a/moalmanac/run_example.py
+++ b/moalmanac/run_example.py
@@ -1,6 +1,7 @@
 import moalmanac
 import os
 import subprocess
+import sys
 import time
 
 from datetime import datetime
@@ -44,28 +45,35 @@ input_dictionary = {
     'disable_matchmaking': False,
 }
 
-config_ini_path = "config.ini"
-config_ini = Ini.read(
-    config_ini_path, extended_interpolation=False, convert_to_dictionary=False
-)
+try:
+    config_ini_path = "config.ini"
+    config_ini = Ini.read(
+        config_ini_path, extended_interpolation=False, convert_to_dictionary=False
+    )
 
-dbs_ini_path = "annotation-databases.ini"
-db_paths = Ini.read(
-    dbs_ini_path,
-    extended_interpolation=True,
-    convert_to_dictionary=True,
-    resolve_paths=True,
-)
-db_paths = db_paths['paths']
+    dbs_ini_path = "annotation-databases.ini"
+    db_paths = Ini.read(
+        dbs_ini_path,
+        extended_interpolation=True,
+        convert_to_dictionary=True,
+        resolve_paths=True,
+    )
+    db_paths = db_paths['paths']
 
-dbs_preclinical_ini_path = "preclinical-databases.ini"
-preclinical_db_paths = Ini.read(
-    dbs_preclinical_ini_path,
-    extended_interpolation=True,
-    convert_to_dictionary=True,
-    resolve_paths=True,
-)
-preclinical_db_paths = preclinical_db_paths['paths']
+    dbs_preclinical_ini_path = "preclinical-databases.ini"
+    preclinical_db_paths = Ini.read(
+        dbs_preclinical_ini_path,
+        extended_interpolation=True,
+        convert_to_dictionary=True,
+        resolve_paths=True,
+    )
+    preclinical_db_paths = preclinical_db_paths['paths']
+except FileNotFoundError as e:
+    print(f"ERROR: {e}", file=sys.stderr)
+    sys.exit(2)
+except RuntimeError as e:
+    print(f"ERROR: {e}", file=sys.stderr)
+    sys.exit(2)
 
 
 def execute_cmd(command):

--- a/moalmanac/run_example.py
+++ b/moalmanac/run_example.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import time
 
-from datetime import date
+from datetime import datetime
 
 from reader import Ini
 
@@ -15,7 +15,7 @@ metadata_dictionary = {
     'purity': 0.85,
     'ploidy': 4.02,
     'WGD': True,
-    'microsatellite_status': 'msih'
+    'microsatellite_status': 'msih',
 }
 
 input_dictionary_empty = {
@@ -28,7 +28,7 @@ input_dictionary_empty = {
     'germline_handle': '',
     'validation_handle': '',
     'mutational_signatures_path': '',
-    'disable_matchmaking': False
+    'disable_matchmaking': False,
 }
 
 input_dictionary = {
@@ -41,18 +41,30 @@ input_dictionary = {
     'germline_handle': '../example_data/example_patient.capture.germline.maf',
     'validation_handle': '../example_data/example_patient.rna.somatic.snvs.maf',
     'mutational_signatures_path': '../example_data/example_patient.capture.sbs_contributions.txt',
-    'disable_matchmaking': False
+    'disable_matchmaking': False,
 }
 
 config_ini_path = "config.ini"
-config_ini = Ini.read(config_ini_path, extended_interpolation=False, convert_to_dictionary=False)
+config_ini = Ini.read(
+    config_ini_path, extended_interpolation=False, convert_to_dictionary=False
+)
 
 dbs_ini_path = "annotation-databases.ini"
-db_paths = Ini.read(dbs_ini_path, extended_interpolation=True, convert_to_dictionary=True)
+db_paths = Ini.read(
+    dbs_ini_path,
+    extended_interpolation=True,
+    convert_to_dictionary=True,
+    resolve_paths=True,
+)
 db_paths = db_paths['paths']
 
 dbs_preclinical_ini_path = "preclinical-databases.ini"
-preclinical_db_paths = Ini.read(dbs_preclinical_ini_path, extended_interpolation=True, convert_to_dictionary=True)
+preclinical_db_paths = Ini.read(
+    dbs_preclinical_ini_path,
+    extended_interpolation=True,
+    convert_to_dictionary=True,
+    resolve_paths=True,
+)
 preclinical_db_paths = preclinical_db_paths['paths']
 
 
@@ -60,8 +72,8 @@ def execute_cmd(command):
     subprocess.call(command, shell=True)
 
 
-today = date.today().isoformat()
-output_directory = f"{today}-example-outputs"
+now = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+output_directory = f"{now}-example-outputs"
 if output_directory != "":
     cmd = f"mkdir -p {output_directory}"
     execute_cmd(cmd)
@@ -75,9 +87,11 @@ moalmanac.main(
     output_folder=output_directory,
     config=config_ini,
     dbs=db_paths,
-    dbs_preclinical=preclinical_db_paths
+    dbs_preclinical=preclinical_db_paths,
 )
 end_time = time.time()
 
-time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round((end_time - start_time), 4)
+time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round(
+    (end_time - start_time), 4
+)
 print(time_statement)


### PR DESCRIPTION
The "root" variable of moalmanac/annotation-databases.ini and moalmanac/preclinical-databases.ini was "../datasources" to be a relative directory. Here, we change this to resolve to an absolute path and also provide a sys.exit() with error message if a provided ini file is not found. The interpreter version was increased to 0.8.6.

This new behavior was tested to ensure successful runtime execution on both a local system and within a Docker container for cloud usage.

If calling `moalmanac/moalmanac.py`'s main function directly and you want to have `moalmanac/annotation-datasources.ini` and `moalmanac/preclinical-databases.ini` resolve to full paths before passing the loaded dictionaries as arguments, add `Ini.read(..., resolve_paths=True)`. [For example](https://github.com/vanallenlab/moalmanac/blob/0e6d274339b1276748229a83475f119680a2fe3c/moalmanac/moalmanac.py#L1132-L1169):
```
db_paths = Ini.read(
    args.dbs,
    extended_interpolation=True,
    convert_to_dictionary=True,
    resolve_paths=True,
)
db_paths = db_paths['paths']

if args.preclinical_dbs:
    preclinical_db_paths = Ini.read(
        args.preclinical_dbs,
        extended_interpolation=True,
        convert_to_dictionary=True,
        resolve_paths=True,
    )
    preclinical_db_paths = preclinical_db_paths['paths']
else:
    preclinical_db_paths = None

main(
    patient=patient_dict,
    inputs=inputs_dict,
    output_folder=output_directory,
    config=config_ini,
    dbs=db_paths,
    dbs_preclinical=preclinical_db_paths,
)
```

Additions:
- A new function `Ini.resolve_paths_dict` in `moalmanac/reader.py` to resolve all paths in datasource ini files to be absolute paths. 
- A new function `Load.validate_and_log_paths` was added to `moalmanac/moalmanac.py` to check and log if the paths provided in the inputs dictionary exist. **If a path is not None or "" and does not exist, a sys.exit() will not be produced**. [Input loaders](https://github.com/vanallenlab/moalmanac/blob/0e6d274339b1276748229a83475f119680a2fe3c/moalmanac/features.py) were written to only read if the provided path exists.

Revisions:
- The function `Ini.read` in `moalmanac/reader.py` was revised to call a new function `Ini.resolve_paths_dict` if the argument `resolve_paths=True`. The default behavior is `resolve_paths=False`. 
- `moalmanac/moalmanac.py`'s argparser section, `run_example.py`, and `run_4x_for_output_regression_test.py` was updated to use `resolve_paths=True` when calling `Ini.read()`
- `run_example.py`'s was revised to create a folder name based on the datetime instead of just date.
- `moalmanac/reader.py`'s `Ini.load()` will raise an error if the path specified in a loaded `ini` file either does not exist or is a folder. 

Pre-pull request check list,
- [x] Relevant documentation has been updated
- [x] All unit tests pass
- [x] All outputs pre- and post- changes match by md5 hash
- [x] All files changed have been reviewed
- [x] Docker pushed
