### PR TITLE
Added os.makedir to main function

### DIFF
--- a/moalmanac/moalmanac.py
+++ b/moalmanac/moalmanac.py
@@ -737,6 +737,7 @@ def process_preclinical_efficacy(
 
 
 def main(patient, inputs, output_folder, config, dbs, dbs_preclinical=None):
+    os.makedirs(output_folder, exist_ok=True)
     start_time = time.time()
     start_datetime = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     environment_metadata = start_logging(


### PR DESCRIPTION
Added output folder creation to moalmanac's main function. To date, output folder creation was handled by the wrapper files, such as run_example.py. 

Additions:
- Added `os.makedir(output_folder, exist_ok=True)` to the beginning of moalmanac/moalmanac.py's main function.

Pre-pull request check list,
- [ ] Relevant documentation has been updated
- [x] All unit tests pass
- [ ] All outputs pre- and post- changes match by md5 hash
- [x] All files changed have been reviewed
- [ ] Docker pushed
