### PR TITLE
Added TMB as an optional float input

### DIFF
--- a/docs/description-of-inputs.md
+++ b/docs/description-of-inputs.md
@@ -1,10 +1,10 @@
 # Description of inputs for Molecular Oncology Almanac
 
-Example inputs can be found in the [`example_data/`](/example_data/) folder, found in the root directory of this repository. 
+Example inputs can be found in the [`example_data/`](/example_data/) folder, found in the root directory of this repository.
 
 # Table of Contents
 The following describes required and optional arguments to run `moalmanac/moalmanac.py`.
-* [Required arguments](#required-arguments)  
+* [Required arguments](#required-arguments)
     - [Patient id](#patient-id)
     - [Config](#config)
     - [Databases](#databases)
@@ -23,28 +23,29 @@ The following describes required and optional arguments to run `moalmanac/moalma
     - [Mutational signatures](#mutational-signatures)
     - [Purity](#purity)
     - [Ploidy](#ploidy)
+    - [Tumor mutational burden](#tumor-mutational-burden)
     - [Whole genome doubling](#whole-genome-doubling)
     - [Disable matchmaking](#disable-matchmaking)
     - [Description](#description)
     - [Output directory](#output-directory)
     - [Preclinical databases](#preclinical-databases)
 
-Alternatively, a simplified version of the interpretation algorithm can be run by using `moalmanac/simplified_input.py`. 
+Alternatively, a simplified version of the interpretation algorithm can be run by using `moalmanac/simplified_input.py`.
 - [Simplified input arguments](#simplified-input)
-    
+
 # Required arguments
 The following arguments are required to run Molecular Oncology Almanac.
 
 ## Patient id
-`--patient_id` expects a single string value which is used for labeling outputs. 
+`--patient_id` expects a single string value which is used for labeling outputs.
 
 ## Config
-`--config` expects a file path to the [config.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/config.ini) file. 
+`--config` expects a file path to the [config.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/config.ini) file.
 
 This config file contains the following sections,
 - `function_toggle` - allows several features of the MOAlmanac algorithm to be enabled or disabled
 - `logging` - specifies the [level](https://docs.python.org/3/library/logging.html#levels) that the logger should be configured to use
-- `versions` - specifies the versions of the [MOAlmanac algorithm (interpreter)](https://github.com/vanallenlab/moalmanac/releases) and [database](https://github.com/vanallenlab/moalmanac-db/releases).    
+- `versions` - specifies the versions of the [MOAlmanac algorithm (interpreter)](https://github.com/vanallenlab/moalmanac/releases) and [database](https://github.com/vanallenlab/moalmanac-db/releases).
 - `exac` - specifies the allele frequency threshold used with [ExAC](https://github.com/vanallenlab/moalmanac/tree/main/datasources/exac) to specify if a variant is a common variant or not
 - `fusion` - specifies minimum spanning fragments required for review by MOAlmanac, column names expected from inputs, and how "Fusion" should be written from input
 - `mutations` - specifies the minimum coverage and allelic fraction that a variant needs for review by MOAlmanac
@@ -75,26 +76,26 @@ This config file contains a single section `databases` that lists the following:
 For more information about each datasource, view the [datasources directory](../datasources/README.md)
 
 # Optional arguments
-Molecular Oncology Almanac will run successfully given any combination of the following arguments: 
+Molecular Oncology Almanac will run successfully given any combination of the following arguments:
 
 ## Tumor type
-`--tumor_type` expects a string representing the report tumor type. MOAlmanac will attempt to map this string to either an [Oncotree term or code](https://github.com/vanallenlab/moalmanac/tree/main/datasources/oncotree). MOAlmanac will consider clinically relevant matches of the same tumor type prior to considering matches of another tumor type. 
+`--tumor_type` expects a string representing the report tumor type. MOAlmanac will attempt to map this string to either an [Oncotree term or code](https://github.com/vanallenlab/moalmanac/tree/main/datasources/oncotree). MOAlmanac will consider clinically relevant matches of the same tumor type prior to considering matches of another tumor type.
 
 ## Stage
 `--stage` also expects a string and is intended for use to input disease stage. This is not functionally used within the method and only is outputted for display in the produced actionability report.
 
-## Somatic single nucleotide variants 
-`--snv_handle` anticipates a tab delimited file which contains somatic single nucleotide variants (snvs). This file should follow the guideline's set by either TCGA or GDC [Mutation Annotation Format (MAF)](https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/). Insertions and deletions can also be included in this input, the two MAFs are simply concatenated together. 
+## Somatic single nucleotide variants
+`--snv_handle` anticipates a tab delimited file which contains somatic single nucleotide variants (snvs). This file should follow the guideline's set by either TCGA or GDC [Mutation Annotation Format (MAF)](https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/). Insertions and deletions can also be included in this input, the two MAFs are simply concatenated together.
 
 ### Example
-|Hugo Symbol|NCBI_Build|Chromosome|Start_position|End_position|Reference_Allele|Tumor_Seq_Allele1|Tumor_Seq_Allele2|Variant_Classification|Tumor_Sample_Barcode|Matched_Norm_Sample_Barcode|Annotation_Transcript|Protein_Change|t_ref_count|t_alt_count|  
+|Hugo Symbol|NCBI_Build|Chromosome|Start_position|End_position|Reference_Allele|Tumor_Seq_Allele1|Tumor_Seq_Allele2|Variant_Classification|Tumor_Sample_Barcode|Matched_Norm_Sample_Barcode|Annotation_Transcript|Protein_Change|t_ref_count|t_alt_count|
 |-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|
 |BRAF|37|7|140453136|140453136|A|T|A|Missense_Mutation|ProfileA-Tumor|ProfileA-Normal|ENST00000288602.6|p.V600E|70|35|
-|MSH2|37|2|47739466|47739466|G|A|G|Missense_Mutation|ProfileA-Tumor|ProfileA-Normal|ENST00000406134.1|p.D887N|50|25| 
+|MSH2|37|2|47739466|47739466|G|A|G|Missense_Mutation|ProfileA-Tumor|ProfileA-Normal|ENST00000406134.1|p.D887N|50|25|
 |STAG2|37|X|123191810|123191810|A|T|A|Missense_Mutation|ProfileA-Tumor|ProfileA-Normal|ENST00000371160.1|p.F467I|60|20|
 
 ### Required fields
-Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive. 
+Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive.
 - `Hugo_Symbol`, gene symbol associated with the variant
 - `NCBI_Build`, reference genome used
 - `Chromosome`, chromosome of the variant
@@ -110,22 +111,22 @@ Required fields can be changed from their default expectations by editing the ap
 - `t_ref_count`, number of reference alleles observed at genomic position
 - `t_alt_count`, number of alternate alleles observed at genomic position
 
-At least one of the following also must be included: 
+At least one of the following also must be included:
 - `HGVSp_Short`, protein change associated with the variant using the one-letter amino acid codes
-- `Protein_Change`, protein change associated with the variant using the one-letter amino-acid codes 
+- `Protein_Change`, protein change associated with the variant using the one-letter amino-acid codes
 
-## Somatic insertion and deletion variants 
-`--indel_handle` anticipates a tab delimited file which contains somatic insertions and deletions (indels). This file should follow the guideline's set by either TCGA or GDC [Mutation Annotation Format (MAF)](https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/). Single nucleotide variants can also be included in this input, the two MAFs are simply concatenated together. 
+## Somatic insertion and deletion variants
+`--indel_handle` anticipates a tab delimited file which contains somatic insertions and deletions (indels). This file should follow the guideline's set by either TCGA or GDC [Mutation Annotation Format (MAF)](https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/). Single nucleotide variants can also be included in this input, the two MAFs are simply concatenated together.
 
 ### Example
-|Hugo Symbol|NCBI_Build|Chromosome|Start_position|End_position|Reference_Allele|Tumor_Seq_Allele1|Tumor_Seq_Allele2|Variant_Classification|Tumor_Sample_Barcode|Matched_Norm_Sample_Barcode|Annotation_Transcript|Protein_Change|t_ref_count|t_alt_count|  
+|Hugo Symbol|NCBI_Build|Chromosome|Start_position|End_position|Reference_Allele|Tumor_Seq_Allele1|Tumor_Seq_Allele2|Variant_Classification|Tumor_Sample_Barcode|Matched_Norm_Sample_Barcode|Annotation_Transcript|Protein_Change|t_ref_count|t_alt_count|
 |-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|
 |PMPCA|37|9|139312448|139312449|-|G|-|Intron|ProfileA-Tumor|ProfileA-Normal|ENST00000371717.3||92|31|
-|C10orf2|37|10|102748300|102748301|TC|TC|-|Frame_Shift_Del|ProfileA-Tumor|ProfileA-Normal|ENST00000370228.1|p.L112fs|294|28| 
+|C10orf2|37|10|102748300|102748301|TC|TC|-|Frame_Shift_Del|ProfileA-Tumor|ProfileA-Normal|ENST00000370228.1|p.L112fs|294|28|
 |MEST|37|7|130138285|130138285|C|C|-|Frame_Shift_Del|ProfileA-Tumor|ProfileA-Normal|ENST00000223215.4|p.L168fs|60|20|
 
 ### Required fields
-Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive. 
+Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive.
 - `Hugo_Symbol`, gene symbol associated with the variant
 - `NCBI_Build`, reference genome used
 - `Chromosome`, chromosome of the variant
@@ -141,19 +142,19 @@ Required fields can be changed from their default expectations by editing the ap
 - `t_ref_count`, number of reference alleles observed at genomic position
 - `t_alt_count`, number of alternate alleles observed at genomic position
 
-At least one of the following also must be included: 
+At least one of the following also must be included:
 - `HGVSp_Short`, protein change associated with the variant using the one-letter amino acid codes
-- `Protein_Change`, protein change associated with the variant using the one-letter amino-acid codes 
+- `Protein_Change`, protein change associated with the variant using the one-letter amino-acid codes
 
 ## Bases covered
-`--bases_covered_handle` anticipates a tab delimited file which contains a single integer representing the number of bases tested for somatic variants. This is used as the denominator to calculate tumor mutational burden (number of coding somatic variants / somatic bases tested). 
+`--bases_covered_handle` anticipates a tab delimited file which contains a single integer representing the number of bases tested for somatic variants. This is used as the denominator to calculate tumor mutational burden (number of coding somatic variants / somatic bases tested).
 
 ### Example
 |29908096|
 |-|
 
 ### Required fields
-This input is looking for an integer value. 
+This input is looking for an integer value.
 
 ## Called copy number alterations
 `--called_cn_handle` anticipated a tab delimited file which contains one column for gene name and a second for the copy number call. For the latter, only the values `Amplification` and `Deletion` will be used by the Molecular Oncology Almanac.
@@ -169,31 +170,31 @@ This input is looking for an integer value.
 The rows associated with _TP53_, _CDKN2A_, and _EGFR_ will be interpreted and scored by Molecular Oncology Almanac while _BRAF_ will be filtered.
 
 ### Required fields
-Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive. 
+Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive.
 - `gene`, gene symbol associated with the copy number alteration
 - `call`, copy number event of the gene. `Amplification` and `Deletion` are accepted and all other values will be filtered.
 
 ## Copy number alterations
-`--cnv_handle` anticipates a tab delimited file which contains total copy number from a source such as GATK CNV or ReCapSeg, support for allele specific copy number is in progress. This file should have genes associated with segments. Amplifications are called from the top 2.5% of all unique segments and deletions called from the bottom 2.5% of all unique segments. 
+`--cnv_handle` anticipates a tab delimited file which contains total copy number from a source such as GATK CNV or ReCapSeg, support for allele specific copy number is in progress. This file should have genes associated with segments. Amplifications are called from the top 2.5% of all unique segments and deletions called from the bottom 2.5% of all unique segments.
 
 ### Example
-|gene|segment_contig|segment_start|segment_end|sample|segment_mean|  
+|gene|segment_contig|segment_start|segment_end|sample|segment_mean|
 |-|-|-|-|-|-|
 |BRAF|7|140035556|142013739|ProfileA-Tumor|1.250062303|
 |CDKN2A|9|21818453|27173612|ProfileA-Tumor|0.822108092|
 |BOC|3|112282632|113393977|ProfileA-Tumor|0.957205107|
 
 ### Required fields
-Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive. 
+Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive.
 - `gene`, gene symbol associated with the copy number alteration
 - `segment_contig`, chromosome of the copy number alteration
 - `segment_start`, genomic location of the segment's start position
 - `segment_end`, genomic location of the segment's end position
 - `sample`, string associated with the tumor profile
-- `segment_mean`, normalized segment mean 
+- `segment_mean`, normalized segment mean
 
 ## Fusions
-`--fusion_handle` anticipates a tab delimited file which contains fusions, specifically in the format of STAR Fusion. 
+`--fusion_handle` anticipates a tab delimited file which contains fusions, specifically in the format of STAR Fusion.
 
 ### Example
 |#FusionName|SpanningFragCount|LeftBreakpoint|RightBreakpoint|
@@ -203,8 +204,8 @@ Required fields can be changed from their default expectations by editing the ap
 |POLR2A--AP2M1|12|17:7406801|3:183898675|
 
 ### Required fields
-Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive. 
-- `#FusionName`, gene symbols associated with the fusion separated by `--`. Genes are labeled from 5' to 3'. 
+Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive.
+- `#FusionName`, gene symbols associated with the fusion separated by `--`. Genes are labeled from 5' to 3'.
 - `SpanningFragCount`, counts of RNA-seq fragments supporting the fusion
 - `LeftBreakpoint`, genomic position of the fusion's left breakpoint
 - `RightBreakpoint`, genomic position of the fusion's right breakpoint
@@ -213,14 +214,14 @@ Required fields can be changed from their default expectations by editing the ap
 `--germline_handle` anticipates a tab delimited file which contains germline variants (both snvs and indels) associated with a case profile. This file should follow the guideline's set by either TCGA or GDC [Mutation Annotation Format (MAF)](https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/). Column names are **not** case-sensitive.
 
 ### Example
-|Hugo Symbol|NCBI_Build|Chromosome|Start_position|End_position|Reference_Allele|Tumor_Seq_Allele1|Tumor_Seq_Allele2|Variant_Classification|Tumor_Sample_Barcode|Matched_Norm_Sample_Barcode|Annotation_Transcript|Protein_Change|t_ref_count|t_alt_count|  
+|Hugo Symbol|NCBI_Build|Chromosome|Start_position|End_position|Reference_Allele|Tumor_Seq_Allele1|Tumor_Seq_Allele2|Variant_Classification|Tumor_Sample_Barcode|Matched_Norm_Sample_Barcode|Annotation_Transcript|Protein_Change|t_ref_count|t_alt_count|
 |-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|
 |BRAF|37|7|140453136|140453136|A|T|A|Missense_Mutation|ProfileA-Tumor|ProfileA-Normal|ENST00000288602.6|p.V600E|40|25|
-|MSH2|37|2|47739466|47739466|G|A|G|Missense_Mutation|ProfileA-Tumor|ProfileA-Normal|ENST00000406134.1|p.D887N|40|30| 
+|MSH2|37|2|47739466|47739466|G|A|G|Missense_Mutation|ProfileA-Tumor|ProfileA-Normal|ENST00000406134.1|p.D887N|40|30|
 |STAG2|37|X|123191810|123191810|A|T|A|Missense_Mutation|ProfileA-Tumor|ProfileA-Normal|ENST00000371160.1|p.F467I|80|26|
 
 ### Required fields
-Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive. 
+Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive.
 - `Hugo_Symbol`, gene symbol associated with the variant
 - `NCBI_Build`, reference genome used
 - `Chromosome`, chromosome of the variant
@@ -236,24 +237,24 @@ Required fields can be changed from their default expectations by editing the ap
 - `t_ref_count`, number of reference alleles observed at genomic position
 - `t_alt_count`, number of alternate alleles observed at genomic position
 
-At least one of the following also must be included: 
+At least one of the following also must be included:
 - `HGVSp_Short`, protein change associated with the variant using the one-letter amino acid codes
-- `Protein_Change`, protein change associated with the variant using the one-letter amino-acid codes 
+- `Protein_Change`, protein change associated with the variant using the one-letter amino-acid codes
 
 ## Somatic variants from validation sequencing
-`--validation_handle` anticipates a tab delimited file which contains somatic variants (snvs and/or indels) from any form of validation or orthogonal sequencing on the tumor; such as re-sequencing the same tissue or somatic variants called from RNA. This file should follow the guideline's set by either TCGA or GDC [Mutation Annotation Format (MAF)](https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/). 
+`--validation_handle` anticipates a tab delimited file which contains somatic variants (snvs and/or indels) from any form of validation or orthogonal sequencing on the tumor; such as re-sequencing the same tissue or somatic variants called from RNA. This file should follow the guideline's set by either TCGA or GDC [Mutation Annotation Format (MAF)](https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/).
 
 Variants from this file are only used for confirmation and are not used for discovery. Specifically, MOAlmanac will look for reported somatic variants in the validation sequencing and identify if any supporting reads are present and if there is sufficient power for detection. This is consistent with best practices recommended by [Yizhak et al. 2019](https://science.sciencemag.org/content/364/6444/eaaw0726.long).
 
 ### Example
-|Hugo Symbol|NCBI_Build|Chromosome|Start_position|End_position|Reference_Allele|Tumor_Seq_Allele1|Tumor_Seq_Allele2|Variant_Classification|Tumor_Sample_Barcode|Matched_Norm_Sample_Barcode|Annotation_Transcript|Protein_Change|t_ref_count|t_alt_count|  
+|Hugo Symbol|NCBI_Build|Chromosome|Start_position|End_position|Reference_Allele|Tumor_Seq_Allele1|Tumor_Seq_Allele2|Variant_Classification|Tumor_Sample_Barcode|Matched_Norm_Sample_Barcode|Annotation_Transcript|Protein_Change|t_ref_count|t_alt_count|
 |-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|
 |BRAF|37|7|140453136|140453136|A|T|A|Missense_Mutation|ProfileA-Tumor|ProfileA-Normal|ENST00000288602.6|p.V600E|40|25|
-|MSH2|37|2|47739466|47739466|G|A|G|Missense_Mutation|ProfileA-Tumor|ProfileA-Normal|ENST00000406134.1|p.D887N|40|30| 
+|MSH2|37|2|47739466|47739466|G|A|G|Missense_Mutation|ProfileA-Tumor|ProfileA-Normal|ENST00000406134.1|p.D887N|40|30|
 |STAG2|37|X|123191810|123191810|A|T|A|Missense_Mutation|ProfileA-Tumor|ProfileA-Normal|ENST00000371160.1|p.F467I|80|26|
 
 ### Required fields
-Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive. 
+Required fields can be changed from their default expectations by editing the appropriate section of [colnames.ini](https://github.com/vanallenlab/moalmanac/blob/main/moalmanac/colnames.ini). Column names are **not** case-sensitive.
 - `Hugo_Symbol`, gene symbol associated with the variant
 - `NCBI_Build`, reference genome used
 - `Chromosome`, chromosome of the variant
@@ -269,24 +270,24 @@ Required fields can be changed from their default expectations by editing the ap
 - `t_ref_count`, number of reference alleles observed at genomic position
 - `t_alt_count`, number of alternate alleles observed at genomic position
 
-At least one of the following also must be included: 
+At least one of the following also must be included:
 - `HGVSp_Short`, protein change associated with the variant using the one-letter amino acid codes
 - `Protein_Change`, protein change associated with the variant using the one-letter amino-acid codes
 
 ## Microsatellite status
-`--ms_status` is a categorical input for microsatellite status, anticipating one of four options: 
+`--ms_status` is a categorical input for microsatellite status, anticipating one of four options:
 - `--unknown`, when status is unknown
 - `--mss` for microsatellite stable tumors, MSS
 - `--msil` for microsatellite instability "low", MSI-L
-- `--msih` for microsatellite instability "high", MSI-H 
+- `--msih` for microsatellite instability "high", MSI-H
 
-Microsatellite status is reported in the clinical actionability report. 
+Microsatellite status is reported in the clinical actionability report.
 
 ## Mutational signatures
-`--mutational_signatures` anticipates a tab delimited file which contains contributions to Single Base Substitution (SBS) Mutational Signatures from [COSMIC version 3.4](https://cancer.sanger.ac.uk/signatures/sbs/). The file should only contain signature contributions for the tumor sample being studied. We recommend generating SBS mutational signatures with [SigProfilerAssignment](https://github.com/AlexandrovLab/SigProfilerAssignment), and have prepared [a wrapper GitHub repository](https://github.com/vanallenlab/SigProfilerAssignment-wrapper) to run SigProfilerAssignment and format signature contributions as expected.  
+`--mutational_signatures` anticipates a tab delimited file which contains contributions to Single Base Substitution (SBS) Mutational Signatures from [COSMIC version 3.4](https://cancer.sanger.ac.uk/signatures/sbs/). The file should only contain signature contributions for the tumor sample being studied. We recommend generating SBS mutational signatures with [SigProfilerAssignment](https://github.com/AlexandrovLab/SigProfilerAssignment), and have prepared [a wrapper GitHub repository](https://github.com/vanallenlab/SigProfilerAssignment-wrapper) to run SigProfilerAssignment and format signature contributions as expected.
 
 ### Example
-| signature | contribution | 
+| signature | contribution |
 |---|--------------|
 | SBS1 | 0.03846154   |
 | SBS2 | 0            |
@@ -296,8 +297,8 @@ Microsatellite status is reported in the clinical actionability report.
 
 ### Required fields,
 The required fields for this file can be changed from their default expectations by editing the appropriate section of `colnames.ini`. Column names are **not** case sensitive.
-- `signature`, labels for each of the 79 SBS mutational signatures included in COSMIC mutational signatures [version 3.4](https://cancer.sanger.ac.uk/signatures/sbs/) 
-- `contribution`, a float value between 0 and 1 for the row's associated signature weight. This column's values should sum to 1. 
+- `signature`, labels for each of the 79 SBS mutational signatures included in COSMIC mutational signatures [version 3.4](https://cancer.sanger.ac.uk/signatures/sbs/)
+- `contribution`, a float value between 0 and 1 for the row's associated signature weight. This column's values should sum to 1.
 
 ## Purity
 `--purity` anticipates a float value between 0.0 and 1.0 for the reported tumor purity. This is just used for reporting in the clinical actionability report.
@@ -305,17 +306,20 @@ The required fields for this file can be changed from their default expectations
 ## Ploidy
 `--purity` anticipates a float value for the reported tumor ploidy. This is just used for reporting in the clinical actionability report.
 
+## Tumor Mutational Burden
+`--tmb` anticipates a float value for the reported tumor mutational burden. This will be used instead calculating the somatic coding mutational burden of [`--burden_handle`](#bases-covered) if both are provided.
+
 ## Whole genome doubling
-`--wgd` is a boolean argument that, when passed, is interpreted as the tumor harboring a whole-genome doubling event. If passed, MOAlmanac will match against relevant assertions. 
+`--wgd` is a boolean argument that, when passed, is interpreted as the tumor harboring a whole-genome doubling event. If passed, MOAlmanac will match against relevant assertions.
 
 ## Disable matchmaking
-`--disable_matchmaking` removes patient-to-cell line matchmaking from being included in the actionability report. 
+`--disable_matchmaking` removes patient-to-cell line matchmaking from being included in the actionability report.
 
 ## Description
-`--description` is a string input that is generally a free text field for users to enter any additional comments. 
+`--description` is a string input that is generally a free text field for users to enter any additional comments.
 
 ## Output directory
-`--output-directory` allows users to specify an output directory to write outputs to, the current working directory will be used if unspecified. 
+`--output-directory` allows users to specify an output directory to write outputs to, the current working directory will be used if unspecified.
 
 ## Preclinical databases
 `--preclinical-dbs` expects a file path to the [preclinical-databases.ini](../moalmanac/preclinical-databases.ini) file. This argument and ini file are required to run either module that either:

--- a/moalmanac/README.md
+++ b/moalmanac/README.md
@@ -1,4 +1,4 @@
-# Molecular Oncology Almanac 
+# Molecular Oncology Almanac
 Molecular Oncology Almanac can be run by executing either `moalmanac.py` with [standard input formats](#standard-usage) or `simplified_input.py` with [simplified inputs](#simplified-input). Please follow the [installation instructions](../README.md#installation) before use.
 
 ## Standard usage
@@ -26,6 +26,7 @@ Optional arguments:
     --ms_status             <string>    microsatellite status as deemed by MSI sensor, MSI or MSS, default=Unknown
     --purity                <float>     tumor purity
     --ploidy                <float>     tumor ploidy
+    --tmb                   <float>     tumor mutational burden
     --wgd                   <boolean>   specify the occurence of whole genome duplication
     --disable_matchmaking   <boolean>   remove patient-to-cell line matchmaking from report
     --description           <string>    description of patient
@@ -56,12 +57,12 @@ python moalmanac.py \
     --preclinical-dbs preclinical-databases.ini
 ```
 
-These example inputs may also be processed by executing `run_example.py`. 
+These example inputs may also be processed by executing `run_example.py`.
 
-Please also view our additional documentation on the [descriptions of inputs](../docs/description-of-inputs.md) for more details about input file formats. 
+Please also view our additional documentation on the [descriptions of inputs](../docs/description-of-inputs.md) for more details about input file formats.
 
 ## Simplified input
-A simplified input of a single file for somatic variants, germline variants, called copy number alterations, and fusions may also be used for a minimal interpretation. This mode also allows for [MSI status](../docs/description-of-inputs.md#microsatellite-status) and [whole-genome doubling](../docs/description-of-inputs.md#whole-genome-doubling) to be considered. With this format, MOAlmanac will be unable to annotate with any datasources that rely on nucleotide position. 
+A simplified input of a single file for somatic variants, germline variants, called copy number alterations, and fusions may also be used for a minimal interpretation. This mode also allows for [MSI status](../docs/description-of-inputs.md#microsatellite-status) and [whole-genome doubling](../docs/description-of-inputs.md#whole-genome-doubling) to be considered. With this format, MOAlmanac will be unable to annotate with any datasources that rely on nucleotide position.
 
 As with the [standard usage](#standard-usage), additional settings can be set by modifying the [config.ini](#configini) file and column names may be modified by editing the [colnames.ini](#colnamesini) file.
 
@@ -131,12 +132,12 @@ MOAlmanac can be customized by modifying the [config.ini](config.ini) file and c
 
 ### config.ini
 The configuration file [config.ini](config.ini) lets users change settings, thresholds, and input string values. The file contains the following sections,
-- `function_toggle` allows users to enable or disable the [actionability report](../docs/description-of-outputs.md#report), [model_similarity](../docs/description-of-outputs.md#profile-to-cell-line-matchmaking), [mutational signature](../docs/description-of-outputs.md#mutational-signatures), and [preclinical efficacy](../docs/description-of-outputs.md#preclinical-efficacy) functions. 
+- `function_toggle` allows users to enable or disable the [actionability report](../docs/description-of-outputs.md#report), [model_similarity](../docs/description-of-outputs.md#profile-to-cell-line-matchmaking), [mutational signature](../docs/description-of-outputs.md#mutational-signatures), and [preclinical efficacy](../docs/description-of-outputs.md#preclinical-efficacy) functions.
 - `versions` are string inputs to describe the MOAlmanac algorithm and database versions
 - `exac` allows users to specify a threshold for [Allele frequency in ExAC](https://gnomad.broadinstitute.org/help/faf) to identify common variants
 - `fusion` allows users to specify the minimum spanning fragments required for fusions
 - `mutation` allows users to specify minimum values for coverage and allelic fraction for evaluation of somatic and germline variants
-- `seg` allows users to specify thresholds for total copy number 
+- `seg` allows users to specify thresholds for total copy number
 - `signatures` allows users to specify the minimum required contribution to consider mutational signatures
 - `validation_sequencing` allows users to specify minimum power and allelic fraction to consider for variants from validation sequencing
 - `feature_types` allows users to specify strings for considered feature types
@@ -154,7 +155,7 @@ The configuration file [annotation-databases.ini](annotation-databases.ini) lets
 Similar to `annotation-databases.ini`, the configuration file [preclinical-databases.ini](preclinical-databases.ini) lets users change paths to datasources being used to for preclinical comparison functions,  [model_similarity](../docs/description-of-outputs.md#profile-to-cell-line-matchmaking) and [preclinical efficacy](../docs/description-of-outputs.md#preclinical-efficacy).
 
 ## Citation
-If you find this tool or any code herein useful, please cite:  
+If you find this tool or any code herein useful, please cite:
 > [Reardon, B., Moore, N.D., Moore, N.S., *et al*. Integrating molecular profiles into clinical frameworks through the Molecular Oncology Almanac to prospectively guide precision oncology. *Nat Cancer* (2021). https://doi.org/10.1038/s43018-021-00243-3](https://www.nature.com/articles/s43018-021-00243-3)
 
 ## Disclaimer - For research use only

--- a/moalmanac/colnames.ini
+++ b/moalmanac/colnames.ini
@@ -387,6 +387,7 @@ purity = ${maps:purity}
 ploidy = ${maps:ploidy}
 wgd = ${maps:wgd}
 ms_status = ${maps:ms_status}
+tumor_mutational_burden = ${maps:tumor_mutational_burden}
 
 [aneuploidy]
 wgd = ${maps:wgd}
@@ -432,6 +433,7 @@ mutational_burden = ${maps:mutational_burden}
 percentile_tcga = ${maps:percentile_tcga}
 percentile_tcga_tissue = ${maps:percentile_tcga_tissue}
 high_burden_boolean = ${maps:high_burden_boolean}
+tumor_mutational_burden = ${maps:tumor_mutational_burden}
 
 [microsatellite]
 msi = ${maps:msi}

--- a/moalmanac/features.py
+++ b/moalmanac/features.py
@@ -1,14 +1,13 @@
+import os
+import sys
+
 import numpy as np
 import pandas as pd
 import scipy.stats as stats
-import os
-import subprocess
-import sys
-
-from datasources import Lawrence
+from config import COLNAMES
 from reader import Reader
 
-from config import COLNAMES
+from datasources import Lawrence
 
 
 class Features:
@@ -143,7 +142,8 @@ class Features:
     def preallocate_missing_columns(cls, df):
         missing_cols = [col for col in cls.all_columns if col not in df.columns]
         return pd.concat(
-            [df, pd.DataFrame(None, columns=missing_cols, index=df.index)], axis=1
+            [df, pd.DataFrame(None, columns=missing_cols, index=df.index)],
+            axis=1,
         )
 
 
@@ -175,6 +175,7 @@ class BurdenReader:
     percentile_tcga = COLNAMES[burden_section]["percentile_tcga"]
     percentile_tcga_tissue = COLNAMES[burden_section]["percentile_tcga_tissue"]
     high_burden_boolean = COLNAMES[burden_section]["high_burden_boolean"]
+    tumor_mutational_burden = COLNAMES[burden_section]["tumor_mutational_burden"]
 
     high = "High Mutational Burden"
     not_high = "Not high mutational burden"
@@ -216,15 +217,7 @@ class BurdenReader:
         if np.isnan(series[cls.mutational_burden]):
             return False
 
-        if not np.isnan(series[cls.percentile_tcga_tissue]):
-            percentile = series[cls.percentile_tcga_tissue]
-        else:
-            percentile = series[cls.percentile_tcga]
-
-        if (float(percentile) >= 0.80) & (float(series[cls.mutational_burden]) >= 10.0):
-            return True
-        else:
-            return False
+        return float(series[cls.mutational_burden]) >= 10.0
 
     @classmethod
     def evaluate_high_burden_boolean(cls, boolean):
@@ -237,7 +230,7 @@ class BurdenReader:
     def import_feature(cls, handle, patient, variants, dbs, config):
         if os.path.exists(handle):
             bases_covered = float(
-                Reader.read(handle, "\t", index_col=False).columns.tolist()[0]
+                Reader.read(handle, "\t", index_col=False).columns.tolist()[0],
             )
         else:
             bases_covered = np.nan
@@ -248,7 +241,11 @@ class BurdenReader:
         mutations = variants[
             variants[Features.feature_type] == config["feature_types"]["mut"]
         ].shape[0]
-        mutational_burden = cls.calculate_burden(mutations, bases_covered)
+
+        if patient[cls.tumor_mutational_burden]:
+            mutational_burden = float(patient[cls.tumor_mutational_burden])
+        else:
+            mutational_burden = cls.calculate_burden(mutations, bases_covered)
 
         df[cls.n_nonsyn_mutations] = mutations
         df[cls.mutational_burden] = mutational_burden
@@ -256,10 +253,13 @@ class BurdenReader:
         code = patient[cls.code]
         lawrence = Lawrence.import_ds(dbs)
         df[cls.percentile_tcga] = cls.calculate_percentile(
-            lawrence[cls.mutational_burden], mutational_burden
+            lawrence[cls.mutational_burden],
+            mutational_burden,
         )
         df[cls.percentile_tcga_tissue] = cls.calculate_percentile_tissuetype(
-            mutational_burden, lawrence, code
+            mutational_burden,
+            lawrence,
+            code,
         )
 
         burden_boolean = cls.evaluate_high_burden(df)
@@ -285,7 +285,10 @@ class CopyNumber:
             handle = not_called_handle
 
         df = Features.import_if_path_exists(
-            handle, "\t", column_map, comment_character="#"
+            handle,
+            "\t",
+            column_map,
+            comment_character="#",
         )
 
         amplification_string = config["seg"]["amp"]
@@ -293,12 +296,15 @@ class CopyNumber:
         if not df.empty:
             biomarker_type = config["feature_types"]["cna"]
             df[Features.feature_type] = Features.annotate_feature_type(
-                biomarker_type, df.index
+                biomarker_type,
+                df.index,
             )
             df.loc[:, Features.feature] = cls.format_cn_gene(df[Features.feature])
             if called_handle:
                 seg_accept, seg_reject = CopyNumberCalled.process_calls(
-                    df, amplification_string, deletion_string
+                    df,
+                    amplification_string,
+                    deletion_string,
                 )
             else:
                 seg_accept, seg_reject = CopyNumberTotal.process_calls(df, config)
@@ -359,7 +365,12 @@ class CopyNumberTotal(CopyNumber):
 
     @classmethod
     def filter_by_threshold(
-        cls, df, percentile_amp, percentile_del, amp_string, del_string
+        cls,
+        df,
+        percentile_amp,
+        percentile_del,
+        amp_string,
+        del_string,
     ):
         unique_segments = cls.get_unique_segments(df)
         threshold_amp = Features.calculate_percentile(unique_segments, percentile_amp)
@@ -373,11 +384,16 @@ class CopyNumberTotal(CopyNumber):
         ].index
 
         df[Features.alt_type] = cls.annotate_amp_del(
-            df.index, idx_amp, idx_del, amp_string, del_string
+            df.index,
+            idx_amp,
+            idx_del,
+            amp_string,
+            del_string,
         )
         idx_accept = df[df[Features.alt_type] != ""].index
         idx_unique = Features.drop_duplicate_genes(
-            df.loc[idx_accept, :], Features.segment_mean
+            df.loc[idx_accept, :],
+            Features.segment_mean,
         )
 
         df[Features.segment_mean] = df[Features.segment_mean].astype(float).round(3)
@@ -397,7 +413,11 @@ class CopyNumberTotal(CopyNumber):
         amp_string = config["seg"]["amp"]
         del_string = config["seg"]["del"]
         return cls.filter_by_threshold(
-            dataframe, amp_percentile, del_percentile, amp_string, del_string
+            dataframe,
+            amp_percentile,
+            del_percentile,
+            amp_string,
+            del_string,
         )
 
 
@@ -461,7 +481,7 @@ class CoverageMetrics:
     def safe_cast(value):
         try:
             return int(value)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             return pd.NA
 
     @staticmethod
@@ -498,7 +518,8 @@ class CosmicSignatures:
             df[Features.alt_type] = "v3.4"
             df.loc[:, Features.alt] = cls.round_contributions(df[Features.alt])
             idx = cls.index_for_minimum_contribution(
-                series=df[Features.alt], minimum_value=minimum_contribution
+                series=df[Features.alt],
+                minimum_value=minimum_contribution,
             )
             return df[idx]
         else:
@@ -559,17 +580,20 @@ class Fusion:
 
             biomarker_type = config["feature_types"]["fusion"]
             df.loc[:, Features.feature_type] = Features.annotate_feature_type(
-                biomarker_type, df.index
+                biomarker_type,
+                df.index,
             )
             df.loc[:, Features.alt_type] = config["fusion"]["alt_Type"]
             df.loc[:, Features.alt] = df[Features.feature]
 
             min_fragments = config["fusion"]["spanningfrags_min"]
             idx_min_spanning_fragments = cls.filter_by_spanning_fragment_count(
-                series=df[Features.spanningfrags], minimum=min_fragments
+                series=df[Features.spanningfrags],
+                minimum=min_fragments,
             )
             idx_unique = Features.drop_duplicate_genes(
-                df.loc[idx_min_spanning_fragments, :], Features.feature
+                df.loc[idx_min_spanning_fragments, :],
+                Features.feature,
             )
             fusions_unique = df.loc[idx_unique, :]
 
@@ -588,7 +612,7 @@ class Fusion:
     @staticmethod
     def split_genes(series_gene):
         return series_gene.str.split("--", expand=True).rename(
-            columns={0: Features.left_gene, 1: Features.right_gene}
+            columns={0: Features.left_gene, 1: Features.right_gene},
         )
 
     @staticmethod
@@ -648,7 +672,7 @@ class MAF(Features):
             return "gdc_maf_input"
         else:
             sys.exit(
-                "Neither 'Protein_Change' nor 'HGVSp_Short' are present columns, cannot map to MAF format"
+                "Neither 'Protein_Change' nor 'HGVSp_Short' are present columns, cannot map to MAF format",
             )
 
     @classmethod
@@ -673,9 +697,16 @@ class MAF(Features):
     @classmethod
     def format_maf(cls, df, feature_type):
         df = Features.preallocate_missing_columns(df)
-        df.loc[:, Features.feature_type] = cls.annotate_feature_type(feature_type, df.index)
-        df.loc[:, Features.alt_count] = CoverageMetrics.format_coverage_col(df[cls.alt_count])
-        df.loc[:, Features.ref_count] = CoverageMetrics.format_coverage_col(df[cls.ref_count])
+        df.loc[:, Features.feature_type] = cls.annotate_feature_type(
+            feature_type,
+            df.index,
+        )
+        df.loc[:, Features.alt_count] = CoverageMetrics.format_coverage_col(
+            df[cls.alt_count],
+        )
+        df.loc[:, Features.ref_count] = CoverageMetrics.format_coverage_col(
+            df[cls.ref_count],
+        )
         df.loc[:, Features.coverage] = CoverageMetrics.calculate_coverage(
             df[cls.alt_count],
             df[cls.ref_count],
@@ -684,7 +715,9 @@ class MAF(Features):
             df[cls.alt_count],
             df[cls.coverage],
         )
-        df.loc[:, Features.alt_type] = cls.rename_coding_classifications(df[cls.alt_type])
+        df.loc[:, Features.alt_type] = cls.rename_coding_classifications(
+            df[cls.alt_type],
+        )
         return df
 
     @classmethod
@@ -799,7 +832,7 @@ class Simple:
             return cls.column_map_gene
         else:
             sys.exit(
-                "Neither 'feature' nor 'gene' are present columns, cannot read input file"
+                "Neither 'feature' nor 'gene' are present columns, cannot read input file",
             )
 
     @classmethod

--- a/moalmanac/moalmanac.py
+++ b/moalmanac/moalmanac.py
@@ -47,6 +47,7 @@ purity = COLNAMES[patient_section]["purity"]
 ploidy = COLNAMES[patient_section]["ploidy"]
 wgd = COLNAMES[patient_section]["wgd"]
 ms_status = COLNAMES[patient_section]["ms_status"]
+tmb = COLNAMES[patient_section]["tumor_mutational_burden"]
 
 oncotree_section = "oncotree"
 ontology = COLNAMES[oncotree_section]["ontology"]
@@ -251,38 +252,35 @@ class Load:
             features.BurdenReader.high_burden_boolean,
         ]
 
-        if path:
+        if patient_dictionary[tmb]:
+            tmb_value = patient_dictionary[tmb]
+            logger.Messages.general(
+                message=f"Somatic coding mutational burden provided: {tmb_value}",
+            )
+        elif path:
             logger.Messages.general(message=f"Somatic bases covered from {path}")
-            somatic_burden = features.BurdenReader.import_feature(
-                handle=path,
-                patient=patient_dictionary,
-                variants=variants,
-                dbs=dbs,
-                config=config,
-            )
-            logger.Messages.general(
-                message="Somatic coding tumor mutational burden calculated",
-            )
-            for column in columns:
-                linebreak = True if column == columns[-1] else False
-                logger.Messages.general(
-                    message=f"...{column}: {somatic_burden.loc[0, column]}",
-                    add_line_break=linebreak,
-                )
         else:
-            logger.Messages.general(
-                message="No input file for somatic bases covered provided",
-            )
+            message = "No TMB value or an somatic bases covered file provided."
+            logger.Messages.general(message=message)
             logger.Messages.general(
                 message="...no input file provided to load",
                 add_line_break=True,
             )
-            somatic_burden = features.BurdenReader.import_feature(
-                handle=path,
-                patient=patient_dictionary,
-                variants=variants,
-                dbs=dbs,
-                config=config,
+        somatic_burden = features.BurdenReader.import_feature(
+            handle=path,
+            patient=patient_dictionary,
+            variants=variants,
+            dbs=dbs,
+            config=config,
+        )
+        logger.Messages.general(
+            message="...somatic coding tumor mutational burden calculated",
+        )
+        for column in columns:
+            linebreak = column == columns[-1]
+            logger.Messages.general(
+                message=f"...{column}: {somatic_burden.loc[0, column]}",
+                add_line_break=linebreak,
             )
         return somatic_burden
 
@@ -711,6 +709,16 @@ def plot_preclinical_efficacy(dictionary, folder, label):
             figure = therapy_dictionary["figure"]
             figure_name = therapy_dictionary["figure_name"]
             writer.Illustrations.write(figure, folder, label, f"{figure_name}.png")
+
+
+def positive_float(value):
+    """
+    Custom type for argparse argument, requires a float value > 0.0.
+    """
+    float_value = float(value)
+    if float_value <= 0:
+        raise argparse.ArgumentTypeError(f"{value} is not a positive float")
+    return float_value
 
 
 def process_preclinical_efficacy(
@@ -1243,6 +1251,12 @@ if __name__ == "__main__":
         help="file for SBS signature contributions, version 3.4",
     )
     arg_parser.add_argument(
+        "--tmb",
+        default=None,
+        help="A positive float value for tumor mutational burden",
+        type=positive_float,
+    )
+    arg_parser.add_argument(
         "--purity",
         default="Unknown",
         help="Tumor purity",
@@ -1293,6 +1307,7 @@ if __name__ == "__main__":
         purity: args.purity,
         ploidy: args.ploidy,
         ms_status: args.ms_status,
+        tmb: args.tmb,
         wgd: args.wgd,
     }
 

--- a/moalmanac/run_4x_for_output_regression_test.py
+++ b/moalmanac/run_4x_for_output_regression_test.py
@@ -11,45 +11,48 @@ pre_or_post_code_changes = "pre"
 # pre_or_post_code_changes = "post"
 
 metadata_dictionary = {
-    'patient_id': 'example',
-    'reported_tumor_type': 'MEL',
-    'stage': 'Metastatic',
-    'description': 'Test patient for development runs',
-    'purity': 0.85,
-    'ploidy': 4.02,
-    'WGD': True,
-    'microsatellite_status': 'msih',
+    "patient_id": "example",
+    "reported_tumor_type": "MEL",
+    "stage": "Metastatic",
+    "description": "Test patient for development runs",
+    "purity": 0.85,
+    "ploidy": 4.02,
+    "WGD": True,
+    "microsatellite_status": "msih",
+    "tumor_mutational_burden": 10.1,
 }
 
 input_dictionary_empty = {
-    'snv_handle': '',
-    'indel_handle': '',
-    'bases_covered_handle': '',
-    'called_cn_handle': '',
-    'cnv_handle': '',
-    'fusion_handle': '',
-    'germline_handle': '',
-    'validation_handle': '',
-    'mutational_signatures_path': '',
-    'disable_matchmaking': False,
+    "snv_handle": "",
+    "indel_handle": "",
+    "bases_covered_handle": "",
+    "called_cn_handle": "",
+    "cnv_handle": "",
+    "fusion_handle": "",
+    "germline_handle": "",
+    "validation_handle": "",
+    "mutational_signatures_path": "",
+    "disable_matchmaking": False,
 }
 
 input_dictionary = {
-    'snv_handle': '../example_data/example_patient.capture.somatic.snvs.maf',
-    'indel_handle': '../example_data/example_patient.capture.somatic.indels.maf',
-    'bases_covered_handle': '../example_data/example_patient.capture.somatic.coverage.txt',
-    'called_cn_handle': '../example_data/example_patient.capture.somatic.called.cna.txt',
-    'cnv_handle': '../example_data/example_patient.capture.somatic.seg.annotated',
-    'fusion_handle': '../example_data/example_patient.rna.star.fusions.txt',
-    'germline_handle': '../example_data/example_patient.capture.germline.maf',
-    'validation_handle': '../example_data/example_patient.rna.somatic.snvs.maf',
-    'mutational_signatures_path': '../example_data/example_patient.capture.sbs_contributions.txt',
-    'disable_matchmaking': False,
+    "snv_handle": "../example_data/example_patient.capture.somatic.snvs.maf",
+    "indel_handle": "../example_data/example_patient.capture.somatic.indels.maf",
+    "bases_covered_handle": "../example_data/example_patient.capture.somatic.coverage.txt",
+    "called_cn_handle": "../example_data/example_patient.capture.somatic.called.cna.txt",
+    "cnv_handle": "../example_data/example_patient.capture.somatic.seg.annotated",
+    "fusion_handle": "../example_data/example_patient.rna.star.fusions.txt",
+    "germline_handle": "../example_data/example_patient.capture.germline.maf",
+    "validation_handle": "../example_data/example_patient.rna.somatic.snvs.maf",
+    "mutational_signatures_path": "../example_data/example_patient.capture.sbs_contributions.txt",
+    "disable_matchmaking": False,
 }
 
 config_ini_path = "config.ini"
 config_ini = Ini.read(
-    config_ini_path, extended_interpolation=False, convert_to_dictionary=False
+    config_ini_path,
+    extended_interpolation=False,
+    convert_to_dictionary=False,
 )
 
 dbs_ini_path = "annotation-databases.ini"
@@ -59,7 +62,7 @@ db_paths = Ini.read(
     convert_to_dictionary=True,
     resolve_paths=True,
 )
-db_paths = db_paths['paths']
+db_paths = db_paths["paths"]
 
 dbs_preclinical_ini_path = "preclinical-databases.ini"
 preclinical_db_paths = Ini.read(
@@ -68,7 +71,7 @@ preclinical_db_paths = Ini.read(
     convert_to_dictionary=True,
     resolve_paths=True,
 )
-preclinical_db_paths = preclinical_db_paths['paths']
+preclinical_db_paths = preclinical_db_paths["paths"]
 
 
 def execute_cmd(command):
@@ -80,8 +83,8 @@ today = date.today().isoformat()
 """
 First execution, all example inputs with all settings within the function toggle enabled
 """
-for key, value in config_ini.items('function_toggle'):
-    config_ini['function_toggle'][key] = 'on'
+for key, value in config_ini.items("function_toggle"):
+    config_ini["function_toggle"][key] = "on"
 
 output_directory = (
     f"{today}-example-outputs-full-all-enabled-{pre_or_post_code_changes}"
@@ -105,16 +108,15 @@ moalmanac.main(
 
 end_time = time.time()
 
-time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round(
-    (end_time - start_time), 4
-)
+elapsed_time = round(end_time - start_time, 4)
+time_statement = f"Molecular Oncology Almanac runtime: {elapsed_time} seconds"
 print(time_statement)
 
 """
 Second execution, all empty example inputs with all settings within the function toggle enabled
 """
-for key, value in config_ini.items('function_toggle'):
-    config_ini['function_toggle'][key] = 'on'
+for key, value in config_ini.items("function_toggle"):
+    config_ini["function_toggle"][key] = "on"
 
 output_directory = (
     f"{today}-example-outputs-empty-all-enabled-{pre_or_post_code_changes}"
@@ -136,16 +138,15 @@ moalmanac.main(
 )
 end_time = time.time()
 
-time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round(
-    (end_time - start_time), 4
-)
+elapsed_time = round(end_time - start_time, 4)
+time_statement = f"Molecular Oncology Almanac runtime: {elapsed_time} seconds"
 print(time_statement)
 
 """
 Third execution, all example inputs with all settings within the function toggle disabled
 """
-for key, value in config_ini.items('function_toggle'):
-    config_ini['function_toggle'][key] = 'off'
+for key, value in config_ini.items("function_toggle"):
+    config_ini["function_toggle"][key] = "off"
 
 output_directory = (
     f"{today}-example-outputs-full-all-disabled-{pre_or_post_code_changes}"
@@ -169,16 +170,15 @@ moalmanac.main(
 
 end_time = time.time()
 
-time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round(
-    (end_time - start_time), 4
-)
+elapsed_time = round(end_time - start_time, 4)
+time_statement = f"Molecular Oncology Almanac runtime: {elapsed_time} seconds"
 print(time_statement)
 
 """
 Fourth execution, all empty example inputs with all settings within the function toggle disabled
 """
-for key, value in config_ini.items('function_toggle'):
-    config_ini['function_toggle'][key] = 'off'
+for key, value in config_ini.items("function_toggle"):
+    config_ini["function_toggle"][key] = "off"
 
 output_directory = (
     f"{today}-example-outputs-empty-all-disabled-{pre_or_post_code_changes}"
@@ -200,7 +200,6 @@ moalmanac.main(
 )
 end_time = time.time()
 
-time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round(
-    (end_time - start_time), 4
-)
+elapsed_time = round(end_time - start_time, 4)
+time_statement = f"Molecular Oncology Almanac runtime: {elapsed_time} seconds"
 print(time_statement)

--- a/moalmanac/run_example.py
+++ b/moalmanac/run_example.py
@@ -1,54 +1,57 @@
-import moalmanac
 import os
 import subprocess
 import sys
 import time
-
 from datetime import datetime
 
 from reader import Ini
 
+import moalmanac
+
 metadata_dictionary = {
-    'patient_id': 'example',
-    'reported_tumor_type': 'MEL',
-    'stage': 'Metastatic',
-    'description': 'Test patient for development runs',
-    'purity': 0.85,
-    'ploidy': 4.02,
-    'WGD': True,
-    'microsatellite_status': 'msih',
+    "patient_id": "example",
+    "reported_tumor_type": "MEL",
+    "stage": "Metastatic",
+    "description": "Test patient for development runs",
+    "purity": 0.85,
+    "ploidy": 4.02,
+    "WGD": True,
+    "microsatellite_status": "msih",
+    "tumor_mutational_burden": 10.1,
 }
 
 input_dictionary_empty = {
-    'snv_handle': '',
-    'indel_handle': '',
-    'bases_covered_handle': '',
-    'called_cn_handle': '',
-    'cnv_handle': '',
-    'fusion_handle': '',
-    'germline_handle': '',
-    'validation_handle': '',
-    'mutational_signatures_path': '',
-    'disable_matchmaking': False,
+    "snv_handle": "",
+    "indel_handle": "",
+    "bases_covered_handle": "",
+    "called_cn_handle": "",
+    "cnv_handle": "",
+    "fusion_handle": "",
+    "germline_handle": "",
+    "validation_handle": "",
+    "mutational_signatures_path": "",
+    "disable_matchmaking": False,
 }
 
 input_dictionary = {
-    'snv_handle': '../example_data/example_patient.capture.somatic.snvs.maf',
-    'indel_handle': '../example_data/example_patient.capture.somatic.indels.maf',
-    'bases_covered_handle': '../example_data/example_patient.capture.somatic.coverage.txt',
-    'called_cn_handle': '../example_data/example_patient.capture.somatic.called.cna.txt',
-    'cnv_handle': '../example_data/example_patient.capture.somatic.seg.annotated',
-    'fusion_handle': '../example_data/example_patient.rna.star.fusions.txt',
-    'germline_handle': '../example_data/example_patient.capture.germline.maf',
-    'validation_handle': '../example_data/example_patient.rna.somatic.snvs.maf',
-    'mutational_signatures_path': '../example_data/example_patient.capture.sbs_contributions.txt',
-    'disable_matchmaking': False,
+    "snv_handle": "../example_data/example_patient.capture.somatic.snvs.maf",
+    "indel_handle": "../example_data/example_patient.capture.somatic.indels.maf",
+    "bases_covered_handle": "../example_data/example_patient.capture.somatic.coverage.txt",
+    "called_cn_handle": "../example_data/example_patient.capture.somatic.called.cna.txt",
+    "cnv_handle": "../example_data/example_patient.capture.somatic.seg.annotated",
+    "fusion_handle": "../example_data/example_patient.rna.star.fusions.txt",
+    "germline_handle": "../example_data/example_patient.capture.germline.maf",
+    "validation_handle": "../example_data/example_patient.rna.somatic.snvs.maf",
+    "mutational_signatures_path": "../example_data/example_patient.capture.sbs_contributions.txt",
+    "disable_matchmaking": False,
 }
 
 try:
     config_ini_path = "config.ini"
     config_ini = Ini.read(
-        config_ini_path, extended_interpolation=False, convert_to_dictionary=False
+        config_ini_path,
+        extended_interpolation=False,
+        convert_to_dictionary=False,
     )
 
     dbs_ini_path = "annotation-databases.ini"
@@ -58,7 +61,7 @@ try:
         convert_to_dictionary=True,
         resolve_paths=True,
     )
-    db_paths = db_paths['paths']
+    db_paths = db_paths["paths"]
 
     dbs_preclinical_ini_path = "preclinical-databases.ini"
     preclinical_db_paths = Ini.read(
@@ -67,7 +70,7 @@ try:
         convert_to_dictionary=True,
         resolve_paths=True,
     )
-    preclinical_db_paths = preclinical_db_paths['paths']
+    preclinical_db_paths = preclinical_db_paths["paths"]
 except FileNotFoundError as e:
     print(f"ERROR: {e}", file=sys.stderr)
     sys.exit(2)
@@ -99,7 +102,6 @@ moalmanac.main(
 )
 end_time = time.time()
 
-time_statement = "Molecular Oncology Almanac runtime: %s seconds" % round(
-    (end_time - start_time), 4
-)
+elapsed_time = round(end_time - start_time, 4)
+time_statement = f"Molecular Oncology Almanac runtime: {elapsed_time} seconds"
 print(time_statement)


### PR DESCRIPTION
Added TMB as an optional float input to moalmanac.py, to support cases when users do not have the somatic covered bases.

Additions:
- `--tmb` is an optional argument, that must be a positive integer or float value if provided

Revisions:
- Removed requirement for TMB to be in > 80th percentile by tumor type to be considered actionable
- Updated print statements for time elapsed
- Ruff applied linting to features.py and moalmanac.py

Pre-pull request check list,
- [x] Relevant documentation has been updated
- [x] All unit tests pass
- [x] All outputs pre- and post- changes match by md5 hash
- [x] All files changed have been reviewed
- [ ] Docker pushed
